### PR TITLE
Add SL SharePoint search support for production PR

### DIFF
--- a/src/app/(authenticated)/api/document/route.ts
+++ b/src/app/(authenticated)/api/document/route.ts
@@ -1,27 +1,51 @@
 // app/api/document/route.ts
 import { NextRequest, NextResponse } from "next/server";
 import { getToken } from "next-auth/jwt";
-import { decideDept, getUserEmailFromJwtToken } from "@/lib/sl-dept";
+import { decideDept, getEffectiveSlUserEmail, getUserEmailFromJwtToken, resolveSlAccess } from "@/lib/sl-dept";
 import { SearchAzureAISimilarDocuments } from "@/features/chat-page/chat-services/chat-api/chat-api-rag-extension";
+import { hashValue } from "@/features/auth-page/helpers";
+import { userSession } from "@/features/auth-page/helpers";
 
 export async function POST(req: NextRequest) {
   try {
-    const token = await getToken({ req });
-    let email = token ? getUserEmailFromJwtToken(token) : null;
+    let email: string | null = null;
 
-    if (!email && process.env.SL_LOCAL_EMAIL) {
-      email = process.env.SL_LOCAL_EMAIL;
+    // 優先①: executeFunction が付けた x-user-email ヘッダー
+    const headerEmail = req.headers.get("x-user-email") ?? null;
+
+    // 優先②: JWTトークン
+    const token = await getToken({ req }).catch(() => null);
+    const tokenEmail = token ? getUserEmailFromJwtToken(token) : null;
+
+    // 優先③: サーバーセッション
+    let sessionEmail: string | null = null;
+    let sessionDept: string | null = null;
+    try {
+      const session = await userSession();
+      sessionEmail = session?.email ?? null;
+      sessionDept = session?.slDept ?? null;
+    } catch (e) {
+      console.log("[DOC] userSession() failed");
     }
 
-    const deptLower = decideDept({
-      requestedDept: undefined,
-      userEmail: email,
-    });
+    email =
+      headerEmail ||
+      tokenEmail ||
+      sessionEmail ||
+      (process.env.SL_LOCAL_DEFAULT_EMAIL ?? null);
+    email = getEffectiveSlUserEmail(email);
+
+    const deptLower = email
+      ? resolveSlAccess(email).dept
+      : sessionDept?.trim().toLowerCase() ||
+        decideDept({ requestedDept: undefined, userEmail: email });
+    const userHash = email ? hashValue(email) : null;
 
     console.log("[DOC] email =", email);
     console.log("[DOC] deptLower =", deptLower);
+    console.log("[DOC] userHash =", userHash ? "***" : "(none)");
 
-    const results = await SearchAzureAISimilarDocuments(req, deptLower);
+    const results = await SearchAzureAISimilarDocuments(req, deptLower, userHash);
 
     let data: any;
     if (results instanceof Response) {
@@ -40,18 +64,11 @@ export async function POST(req: NextRequest) {
   } catch (err: any) {
     return NextResponse.json(
       { error: true, message: err?.message ?? "Internal error" },
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json; charset=utf-8" },
-      }
+      { status: 500, headers: { "Content-Type": "application/json; charset=utf-8" } }
     );
   }
 }
 
 function safeParse(t: string) {
-  try {
-    return JSON.parse(t);
-  } catch {
-    return { raw: t };
-  }
+  try { return JSON.parse(t); } catch { return { raw: t }; }
 }

--- a/src/app/(authenticated)/api/sl/publish/route.ts
+++ b/src/app/(authenticated)/api/sl/publish/route.ts
@@ -5,13 +5,18 @@ export const runtime = "nodejs";
 import { NextRequest, NextResponse } from "next/server";
 import { getToken } from "next-auth/jwt";
 import {
+  buildUploadFolder,
+  decideDept,
   getDeptConfig,
+  getEffectiveSlUserEmail,
   getUserEmailFromJwtToken,
+  isSharePointEnabledDept,
+  normalizeUploadScope,
+  resolveSlAccess,
+  resolveSlUploadTarget,
+  type UploadScope,
 } from "@/lib/sl-dept";
 
-// -------------------------------------------------------
-// Token refresh helper
-// -------------------------------------------------------
 async function getValidAccessToken(req: NextRequest): Promise<string | null> {
   const token = await getToken({ req });
   if (!token) return null;
@@ -56,7 +61,6 @@ async function getValidAccessToken(req: NextRequest): Promise<string | null> {
       return accessToken;
     }
 
-    console.log("[SL publish] Token refreshed successfully");
     return data.access_token as string;
   } catch (e) {
     console.error("[SL publish] Token refresh error:", e);
@@ -64,60 +68,6 @@ async function getValidAccessToken(req: NextRequest): Promise<string | null> {
   }
 }
 
-// -------------------------------------------------------
-// Helpers
-// -------------------------------------------------------
-function parseCsvLower(value?: string | null) {
-  return (value ?? "")
-    .split(",")
-    .map((s) => s.trim().toLowerCase())
-    .filter(Boolean);
-}
-
-function normalizeEmail(email?: string | null) {
-  return (email ?? "").trim().toLowerCase();
-}
-
-function normalizeDept(value?: string | null) {
-  return (value ?? "").trim().toLowerCase();
-}
-
-// commonアップロード許可用
-function isAdminEmail(email: string | null) {
-  if (!email) return false;
-  const admins = parseCsvLower(process.env.SL_ADMIN_EMAILS);
-  return admins.includes(email.toLowerCase());
-}
-
-// env実名に合わせる
-function getDeptEmailsFromEnv(envName: string): string[] {
-  return parseCsvLower(process.env[envName]);
-}
-
-function getDefaultDept(): "cp" | "ss" | "others" {
-  const raw = normalizeDept(process.env.SL_DEPT_DEFAULT);
-  if (raw === "cp" || raw === "ss" || raw === "others") {
-    return raw;
-  }
-  return "others";
-}
-
-function decideDeptByEmail(email: string | null): "cp" | "ss" | "others" {
-  const e = normalizeEmail(email);
-  if (!e) return getDefaultDept();
-
-  const ssEmails = getDeptEmailsFromEnv("SL_DEPT_BY_EMAIL_SS");
-  const cpEmails = getDeptEmailsFromEnv("SL_DEPT_BY_EMAIL_CP");
-
-  if (ssEmails.includes(e)) return "ss";
-  if (cpEmails.includes(e)) return "cp";
-
-  return getDefaultDept();
-}
-
-// -------------------------------------------------------
-// Graph API helpers
-// -------------------------------------------------------
 async function resolveSiteAndDrive(
   accessToken: string,
   siteUrl: string,
@@ -132,8 +82,7 @@ async function resolveSiteAndDrive(
     { headers: { Authorization: `Bearer ${accessToken}` } }
   );
   if (!siteRes.ok) {
-    const err = await siteRes.text();
-    throw new Error(`Failed to get site: ${err}`);
+    throw new Error(`Failed to get site: ${await siteRes.text()}`);
   }
   const siteJson = await siteRes.json();
   const siteId: string = siteJson.id;
@@ -143,8 +92,7 @@ async function resolveSiteAndDrive(
     { headers: { Authorization: `Bearer ${accessToken}` } }
   );
   if (!drivesRes.ok) {
-    const err = await drivesRes.text();
-    throw new Error(`Failed to get drives: ${err}`);
+    throw new Error(`Failed to get drives: ${await drivesRes.text()}`);
   }
   const drivesJson = await drivesRes.json();
   const drive = drivesJson.value.find((d: any) => d.name === driveName);
@@ -156,7 +104,7 @@ async function resolveSiteAndDrive(
     );
   }
 
-  return { siteId: siteJson.id, driveId: drive.id };
+  return { siteId, driveId: drive.id };
 }
 
 async function graphPutBinary(
@@ -165,46 +113,48 @@ async function graphPutBinary(
   buffer: Buffer,
   mimeType: string
 ): Promise<any> {
-  // ★ SharedArrayBuffer問題を回避：Buffer を Uint8Array に変換
-  const uint8 = new Uint8Array(buffer);
-
   const res = await fetch(uploadUrl, {
     method: "PUT",
     headers: {
       Authorization: `Bearer ${accessToken}`,
       "Content-Type": mimeType,
     },
-    body: uint8,
+    body: new Uint8Array(buffer),
   });
 
   if (!res.ok) {
-    const err = await res.text();
-    throw new Error(`Upload failed (${res.status}): ${err}`);
+    throw new Error(`Upload failed (${res.status}): ${await res.text()}`);
   }
   return res.json();
 }
 
-// -------------------------------------------------------
-// Route handlers
-// -------------------------------------------------------
+function getMimeType(fileName: string): string {
+  const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
+
+  const mimeMap: Record<string, string> = {
+    pdf: "application/pdf",
+    docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    txt: "text/plain",
+  };
+
+  return mimeMap[ext] ?? "application/octet-stream";
+}
+
+function resolveRequestedUploadScope(body: any): UploadScope {
+  return normalizeUploadScope(body?.uploadScope ?? body?.dept);
+}
+
 export async function OPTIONS() {
   return NextResponse.json({}, { status: 200 });
 }
 
 export async function POST(req: NextRequest) {
   try {
-    // ---------------------------------------------------
-    // SL機能の有効/無効を最初に判定
-    // false / 未設定 / 空文字 の場合は SharePoint 処理へ入らない
-    // ---------------------------------------------------
-    if (process.env.NEXT_PUBLIC_SL_ENABLED !== "true") {
-      console.log("[SL publish] disabled by NEXT_PUBLIC_SL_ENABLED");
-      return NextResponse.json(
-        { ok: false, disabled: true, error: "SL publish is disabled" },
-        { status: 404 }
-      );
-    }
-
     const accessToken = await getValidAccessToken(req);
     if (!accessToken) {
       return NextResponse.json(
@@ -214,9 +164,8 @@ export async function POST(req: NextRequest) {
     }
 
     const body = await req.json();
-    const fileName = String(body?.fileName ?? "");
-    const fileBase64 = String(body?.fileBase64 ?? "");
-    const requestedDept = normalizeDept(body?.dept);
+    const fileName = String(body.fileName ?? "").replace(/^[\s\u3000]+|[\s\u3000]+$/g, "");
+    const { fileBase64 } = body;
 
     if (!fileName || !fileBase64) {
       return NextResponse.json(
@@ -226,71 +175,74 @@ export async function POST(req: NextRequest) {
     }
 
     const token = await getToken({ req });
-    const userEmail = token ? getUserEmailFromJwtToken(token) : null;
-    const userEmailLower = normalizeEmail(userEmail);
+    const rawUserEmail = token ? getUserEmailFromJwtToken(token) : null;
+    const userEmail = getEffectiveSlUserEmail(rawUserEmail);
 
-    const admin = isAdminEmail(userEmailLower);
-    const allowedDepts = ["cp", "ss", "others", "common"];
-
-    let deptLower: "cp" | "ss" | "others" | "common";
-
-    // 管理者だけ toggle を使える
-    if (admin && requestedDept) {
-      if (!allowedDepts.includes(requestedDept)) {
-        return NextResponse.json(
-          { ok: false, error: `Invalid dept: ${requestedDept}` },
-          { status: 400 }
-        );
-      }
-      deptLower = requestedDept as "cp" | "ss" | "others" | "common";
-    } else {
-      // 非管理者は常にメアド優先
-      deptLower = decideDeptByEmail(userEmailLower);
-    }
-
-    // common は管理者のみ
-    if (deptLower === "common" && !admin) {
+    if (!userEmail) {
       return NextResponse.json(
-        { ok: false, error: "You are not allowed to upload to COMMON." },
-        { status: 403 }
+        { ok: false, error: "Failed to identify current user email." },
+        { status: 401 }
       );
     }
 
-    const { siteUrl, driveName, folder } = getDeptConfig(deptLower);
+    const requestedUploadScope = resolveRequestedUploadScope(body);
+    const preferredDept = decideDept({
+      requestedDept:
+        typeof body?.requestedDept === "string" ? body.requestedDept : undefined,
+      userEmail,
+    });
+
+    const access = resolveSlAccess(userEmail, preferredDept);
+    const admin =
+      access.role === "global_admin" || access.role === "dept_admin";
+    const actualUploadScope: UploadScope = admin
+      ? requestedUploadScope
+      : "personal";
+
+    const uploadTarget = resolveSlUploadTarget(
+      userEmail,
+      actualUploadScope,
+      preferredDept
+    );
+    const targetDept = uploadTarget.dept;
+
+    const isSpDept =
+      targetDept === "common" ? true : isSharePointEnabledDept(targetDept);
+
+    if (!isSpDept) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error:
+            "Your department is not SharePoint-enabled. Use Blob upload flow instead.",
+          dept: targetDept,
+          isSharePointEnabled: false,
+        },
+        { status: 400 }
+      );
+    }
+
+    const { siteUrl, driveName, folder: baseFolder } = getDeptConfig(targetDept);
+    const uploadFolder =
+      targetDept === "common" && actualUploadScope === "common"
+        ? baseFolder
+        : buildUploadFolder({
+            baseFolder,
+            uploadScope: actualUploadScope,
+            userEmail,
+          });
 
     console.log(
-      `[SL publish] requestedDept=${requestedDept || "(empty)"} resolvedDept=${deptLower} admin=${admin} user=${userEmailLower || "unknown"}`
-    );
-    console.log(
-      `[SL publish] env SS=${process.env.SL_DEPT_BY_EMAIL_SS || "(empty)"} CP=${process.env.SL_DEPT_BY_EMAIL_CP || "(empty)"} DEFAULT=${process.env.SL_DEPT_DEFAULT || "(empty)"}`
-    );
-    console.log(
-      `[SL publish] dept=${deptLower} user=${userEmailLower || "unknown"} site=${siteUrl} drive=${driveName} folder=${folder}`
+      `[SL publish] preferredDept=${preferredDept} targetDept=${targetDept} user=${userEmail} role=${access.role} requestedScope=${requestedUploadScope} actualScope=${actualUploadScope} site=${siteUrl} drive=${driveName} folder=${uploadFolder}`
     );
 
     const fileBuffer = Buffer.from(fileBase64, "base64");
+    const mimeType = getMimeType(fileName);
+    const { driveId } = await resolveSiteAndDrive(accessToken, siteUrl, driveName);
 
-    const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
-    const mimeMap: Record<string, string> = {
-      pdf: "application/pdf",
-      docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-      pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      png: "image/png",
-      jpg: "image/jpeg",
-      jpeg: "image/jpeg",
-      txt: "text/plain",
-    };
-    const mimeType = mimeMap[ext] ?? "application/octet-stream";
-
-    const { driveId } = await resolveSiteAndDrive(
-      accessToken,
-      siteUrl,
-      driveName
-    );
-
-    const uploadUrl = `https://graph.microsoft.com/v1.0/drives/${driveId}/root:/${folder}/${fileName}:/content`;
-    console.log(`[SL publish] Uploading to: ${uploadUrl}`);
+    const uploadUrl =
+      `https://graph.microsoft.com/v1.0/drives/${driveId}` +
+      `/root:/${uploadFolder}/${fileName}:/content`;
 
     const result = await graphPutBinary(
       uploadUrl,
@@ -299,13 +251,14 @@ export async function POST(req: NextRequest) {
       mimeType
     );
 
-    console.log(`[SL publish] Upload success: ${result.webUrl}`);
-
     return NextResponse.json({
       ok: true,
-      dept: deptLower,
+      dept: targetDept,
+      uploadScope: actualUploadScope,
+      isSharePointEnabled: true,
       name: result.name,
       webUrl: result.webUrl,
+      spItemId: result.id ?? null,
     });
   } catch (e: any) {
     console.error("[SL publish] Error:", e);

--- a/src/app/(authenticated)/api/sl/sync-check/route.ts
+++ b/src/app/(authenticated)/api/sl/sync-check/route.ts
@@ -1,12 +1,28 @@
 // app/(authenticated)/api/sl/sync-check/route.ts
+//
+// SharePoint SLフォルダと Azure AI Search Index の同期チェック API
+//
+// 変更点:
+// - session access token 方式を廃止
+// - app-only token (client credentials) 方式へ変更
+// - x-sl-sync-key で保護された手動実行APIとして利用
+//
+// 必要な env:
+// - AZURE_AD_TENANT_ID
+// - AZURE_AD_CLIENT_ID
+// - AZURE_AD_CLIENT_SECRET
+// - SL_SYNC_CHECK_KEY
+
 export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
-import { getToken } from "next-auth/jwt";
 import { options as authOptions } from "@/features/auth-page/auth-api";
-import { getDeptConfig, getAllowedDepts } from "@/lib/sl-dept";
+import { runSlSync } from "@/lib/sl-sync";
 
+// -------------------------------------------------------
+// Optional endpoint guard
+// -------------------------------------------------------
 async function requireSyncKey(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if ((session?.user as any)?.email) return;
@@ -20,224 +36,52 @@ async function requireSyncKey(req: NextRequest) {
   }
 }
 
-async function getValidAccessToken(req: NextRequest): Promise<string | null> {
-  const token = await getToken({ req });
-  if (!token) return null;
+// -------------------------------------------------------
+// App-only Graph token (client credentials)
+// -------------------------------------------------------
+async function getAppOnlyAccessToken(): Promise<string> {
+  const tenantId = (process.env.AZURE_AD_TENANT_ID ?? "").trim();
+  const clientId = (process.env.AZURE_AD_CLIENT_ID ?? "").trim();
+  const clientSecret = (process.env.AZURE_AD_CLIENT_SECRET ?? "").trim();
 
-  const accessToken = (token as any).accessToken as string | undefined;
-  const expiresAt = (token as any).accessTokenExpiresAt as number | undefined;
-  const refreshToken = (token as any).refreshToken as string | undefined;
-
-  if (!accessToken) return null;
-
-  const nowSec = Math.floor(Date.now() / 1000);
-  if (expiresAt && nowSec < expiresAt - 60) {
-    return accessToken;
-  }
-
-  if (!refreshToken) return accessToken;
-
-  const tenantId = process.env.AZURE_AD_TENANT_ID;
-  const clientId = process.env.AZURE_AD_CLIENT_ID;
-  const clientSecret = process.env.AZURE_AD_CLIENT_SECRET;
-  if (!tenantId || !clientId || !clientSecret) return accessToken;
-
-  try {
-    const res: Response = await fetch(
-      `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        cache: "no-store",
-        body: new URLSearchParams({
-          client_id: clientId,
-          client_secret: clientSecret,
-          grant_type: "refresh_token",
-          refresh_token: refreshToken,
-          scope: "openid profile email offline_access User.Read Files.ReadWrite",
-        }),
-      }
+  if (!tenantId || !clientId || !clientSecret) {
+    throw new Error(
+      "Missing Azure AD env vars (AZURE_AD_TENANT_ID / AZURE_AD_CLIENT_ID / AZURE_AD_CLIENT_SECRET)"
     );
-
-    const data: any = await res.json().catch(() => ({}));
-    if (!res.ok) {
-      console.error("[SL sync-check] Token refresh failed:", data);
-      return accessToken;
-    }
-
-    return data.access_token as string;
-  } catch (e) {
-    console.error("[SL sync-check] Token refresh error:", e);
-    return accessToken;
-  }
-}
-
-function encodeGraphPath(path: string): string {
-  return (path ?? "")
-    .split("/")
-    .filter((s) => s.length > 0)
-    .map((seg) => encodeURIComponent(seg))
-    .join("/");
-}
-
-async function resolveSiteId(accessToken: string, siteUrl: string): Promise<string> {
-  const url = new URL(siteUrl);
-  const res: Response = await fetch(
-    `https://graph.microsoft.com/v1.0/sites/${url.hostname}:${url.pathname}`,
-    {
-      headers: { Authorization: `Bearer ${accessToken}` },
-      cache: "no-store",
-    }
-  );
-  if (!res.ok) throw new Error(`Failed to get site: ${await res.text()}`);
-  const json = await res.json();
-  return json.id as string;
-}
-
-async function resolveDriveId(
-  accessToken: string,
-  siteId: string,
-  driveName: string
-): Promise<string> {
-  const res: Response = await fetch(
-    `https://graph.microsoft.com/v1.0/sites/${siteId}/drives`,
-    {
-      headers: { Authorization: `Bearer ${accessToken}` },
-      cache: "no-store",
-    }
-  );
-  if (!res.ok) throw new Error(`Failed to get drives: ${await res.text()}`);
-  const json = await res.json();
-  const drive = (json.value ?? []).find((d: any) => d.name === driveName);
-  if (!drive) {
-    const names = (json.value ?? []).map((d: any) => d.name).join(", ");
-    throw new Error(`Drive "${driveName}" not found. Available: ${names}`);
-  }
-  return drive.id as string;
-}
-
-async function getSpFileNames(
-  accessToken: string,
-  siteUrl: string,
-  driveName: string,
-  folder: string
-): Promise<Set<string>> {
-  const siteId = await resolveSiteId(accessToken, siteUrl);
-  const driveId = await resolveDriveId(accessToken, siteId, driveName);
-
-  const folderPath = encodeGraphPath(folder);
-
-  const fileNames = new Set<string>();
-  let nextUrl: string | null =
-    `https://graph.microsoft.com/v1.0/drives/${driveId}` +
-    `/root:/${folderPath}:/children?$select=name,file&$top=200`;
-
-  while (nextUrl) {
-    const res: Response = await fetch(nextUrl, { // ★ 修正箇所
-      headers: { Authorization: `Bearer ${accessToken}` },
-      cache: "no-store",
-    });
-
-    if (res.status === 404) break;
-    if (!res.ok) throw new Error(`Failed to list folder: ${await res.text()}`);
-
-    const json = await res.json();
-    for (const item of json.value ?? []) {
-      if (item?.file && item?.name) fileNames.add(String(item.name));
-    }
-    nextUrl = json["@odata.nextLink"] ?? null;
   }
 
-  return fileNames;
-}
+  const tokenUrl = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
 
-async function getIndexDocs(
-  dept: string
-): Promise<Array<{ id: string; fileName: string }>> {
-  const endpoint = process.env.AZURE_SEARCH_ENDPOINT;
-  const indexName = process.env.AZURE_SEARCH_INDEX_NAME;
-  const apiKey = process.env.AZURE_SEARCH_API_KEY;
+  const res = await fetch(tokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    cache: "no-store",
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "client_credentials",
+      scope: "https://graph.microsoft.com/.default",
+    }),
+  });
 
-  if (!endpoint || !apiKey || !indexName) {
-    throw new Error("Missing Azure Search env vars (AZURE_SEARCH_ENDPOINT/API_KEY/INDEX_NAME)");
+  const data: any = await res.json().catch(() => ({}));
+
+  if (!res.ok) {
+    console.error("[SL sync-check] App token fetch failed:", data);
+    throw new Error(`Failed to get app-only access token: ${JSON.stringify(data)}`);
   }
 
-  const docs: Array<{ id: string; fileName: string }> = [];
-  let skip = 0;
-  const top = 200;
-
-  while (true) {
-    const res: Response = await fetch(
-      `${endpoint}/indexes/${indexName}/docs?api-version=2024-07-01` +
-        `&$select=id,fileUrl,dept` +
-        `&$filter=dept eq '${dept.replace(/'/g, "''")}'` +
-        `&$top=${top}&$skip=${skip}`,
-      {
-        headers: {
-          "api-key": apiKey,
-          "Content-Type": "application/json",
-        },
-        cache: "no-store",
-      }
-    );
-
-    if (!res.ok) throw new Error(`Search query failed: ${await res.text()}`);
-
-    const json = await res.json();
-    const items: any[] = json.value ?? [];
-    if (items.length === 0) break;
-
-    for (const item of items) {
-      const rawUrl: string = item.fileUrl ?? "";
-      const decoded = safeDecodeURIComponent(rawUrl);
-      const fileName = decoded.split("/").pop() ?? "";
-      if (item.id && fileName) docs.push({ id: String(item.id), fileName });
-    }
-
-    skip += items.length;
-    if (items.length < top) break;
+  const accessToken = data?.access_token as string | undefined;
+  if (!accessToken) {
+    throw new Error("No access_token returned from Azure AD");
   }
 
-  return docs;
+  return accessToken;
 }
 
-function safeDecodeURIComponent(v: string): string {
-  try {
-    return decodeURIComponent(v);
-  } catch {
-    return v;
-  }
-}
-
-async function deleteIndexDocs(ids: string[]): Promise<void> {
-  if (ids.length === 0) return;
-
-  const endpoint = process.env.AZURE_SEARCH_ENDPOINT;
-  const apiKey = process.env.AZURE_SEARCH_API_KEY;
-  const indexName = process.env.AZURE_SEARCH_INDEX_NAME;
-
-  if (!endpoint || !apiKey || !indexName) {
-    throw new Error("Missing Azure Search env vars (AZURE_SEARCH_ENDPOINT/API_KEY/INDEX_NAME)");
-  }
-
-  const body = {
-    value: ids.map((id) => ({ "@search.action": "delete", id })),
-  };
-
-  const res: Response = await fetch(
-    `${endpoint}/indexes/${indexName}/docs/index?api-version=2024-07-01`,
-    {
-      method: "POST",
-      headers: { "api-key": apiKey, "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-      cache: "no-store",
-    }
-  );
-
-  if (!res.ok) throw new Error(`Delete failed: ${await res.text()}`);
-  console.log(`[SL sync-check] Deleted ${ids.length} index docs`);
-}
-
+// -------------------------------------------------------
+// Route handlers
+// -------------------------------------------------------
 export async function OPTIONS() {
   return NextResponse.json({}, { status: 200 });
 }
@@ -246,54 +90,17 @@ export async function POST(req: NextRequest) {
   try {
     await requireSyncKey(req);
 
-    const accessToken = await getValidAccessToken(req);
-    if (!accessToken) {
-      return NextResponse.json(
-        { ok: false, error: "No access token in session" },
-        { status: 401 }
-      );
-    }
+    const accessToken = await getAppOnlyAccessToken();
 
-    const results: Record<string, any> = {};
+    const url = new URL(req.url);
+    const apply = url.searchParams.get("apply") === "true";
 
-    for (const dept of getAllowedDepts()) {
-      try {
-        const { siteUrl, driveName, folder } = getDeptConfig(dept);
+    const result = await runSlSync({
+      accessToken,
+      apply,
+    });
 
-        const spFiles = await getSpFileNames(accessToken, siteUrl, driveName, folder);
-        console.log(`[SL sync-check] dept=${dept} SP files=${spFiles.size}`);
-
-        const indexDocs = await getIndexDocs(dept);
-        console.log(`[SL sync-check] dept=${dept} indexed files=${indexDocs.length}`);
-
-        const orphanIds = indexDocs
-          .filter((doc) => !spFiles.has(doc.fileName))
-          .map((doc) => doc.id);
-
-        if (orphanIds.length === 0) {
-          results[dept] = {
-            spFiles: spFiles.size,
-            indexDocs: indexDocs.length,
-            deleted: 0,
-          };
-          continue;
-        }
-
-        console.log(`[SL sync-check] dept=${dept} orphans=${orphanIds.length}`);
-        await deleteIndexDocs(orphanIds);
-
-        results[dept] = {
-          spFiles: spFiles.size,
-          indexDocs: indexDocs.length,
-          deleted: orphanIds.length,
-        };
-      } catch (deptErr: any) {
-        console.error(`[SL sync-check] dept=${dept} error:`, deptErr);
-        results[dept] = { error: String(deptErr?.message ?? deptErr) };
-      }
-    }
-
-    return NextResponse.json({ ok: true, results });
+    return NextResponse.json(result);
   } catch (e: any) {
     console.error("[SL sync-check] Error:", e);
     const msg = String(e?.message ?? e);

--- a/src/app/(authenticated)/chat/[id]/page.tsx
+++ b/src/app/(authenticated)/chat/[id]/page.tsx
@@ -3,6 +3,8 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 import "@/lib/no-store-fetch";
+import { getServerSession } from "next-auth";
+import { options as authOptions } from "@/features/auth-page/auth-api";
 import { ChatPage } from "@/features/chat-page/chat-page";
 import { FindAllChatDocuments } from "@/features/chat-page/chat-services/chat-document-service";
 import { FindAllChatMessagesForCurrentUser } from "@/features/chat-page/chat-services/chat-message-service";
@@ -10,8 +12,7 @@ import { FindChatThreadForCurrentUser } from "@/features/chat-page/chat-services
 import { FindAllExtensionForCurrentUser } from "@/features/extensions-page/extension-services/extension-service";
 import { AI_NAME } from "@/features/theme/theme-config";
 import { DisplayError } from "@/features/ui/error/display-error";
-import { getServerSession } from "next-auth";
-import { options as authOptions } from "@/features/auth-page/auth-api";
+import { resolveSlAccess } from "@/lib/sl-dept";
 
 export const metadata = {
   title: AI_NAME,
@@ -24,31 +25,17 @@ interface HomeParams {
   };
 }
 
-function isAdminEmail(email: string | null | undefined): boolean {
-  if (!email) return false;
-  const admins = (process.env.SL_ADMIN_EMAILS ?? "")
-    .split(",")
-    .map((s) => s.trim().toLowerCase())
-    .filter(Boolean);
-  return admins.includes(email.toLowerCase());
-}
-
 export default async function Home(props: HomeParams) {
   const { id } = props.params;
 
-  const [
-    chatResponse,
-    chatThreadResponse,
-    docsResponse,
-    extensionResponse,
-    session,
-  ] = await Promise.all([
-    FindAllChatMessagesForCurrentUser(id),
-    FindChatThreadForCurrentUser(id),
-    FindAllChatDocuments(id),
-    FindAllExtensionForCurrentUser(),
-    getServerSession(authOptions),
-  ]);
+  const [chatResponse, chatThreadResponse, docsResponse, extensionResponse, session] =
+    await Promise.all([
+      FindAllChatMessagesForCurrentUser(id),
+      FindChatThreadForCurrentUser(id),
+      FindAllChatDocuments(id),
+      FindAllExtensionForCurrentUser(),
+      getServerSession(authOptions),
+    ]);
 
   if (docsResponse.status !== "OK") {
     return <DisplayError errors={docsResponse.errors} />;
@@ -64,18 +51,20 @@ export default async function Home(props: HomeParams) {
   }
 
   const userEmail = session?.user?.email;
-  const adminsRaw = process.env.SL_ADMIN_EMAILS ?? "";
-  const admins = adminsRaw
-    .split(",")
-    .map((s) => s.trim().toLowerCase())
-    .filter(Boolean);
-  const isAdmin = isAdminEmail(userEmail);
+  const sessionRole = session?.user?.slRole;
+  const sessionDept = session?.user?.slDept;
+  const resolvedAccess =
+    sessionRole && sessionDept
+      ? { role: sessionRole, dept: sessionDept }
+      : resolveSlAccess(userEmail);
 
-  console.log("[ADMIN] session.user.email =", userEmail ?? "(null)");
-  console.log("[ADMIN] session.user =", JSON.stringify(session?.user ?? null));
-  console.log("[ADMIN] SL_ADMIN_EMAILS =", adminsRaw || "(empty)");
-  console.log("[ADMIN] parsed admins =", JSON.stringify(admins));
-  console.log("[ADMIN] isAdmin =", isAdmin);
+  const isAdmin =
+    resolvedAccess.role === "global_admin" ||
+    resolvedAccess.role === "dept_admin";
+
+  console.log(
+    `[ROLE] email=${userEmail} dept=${resolvedAccess.dept} role=${resolvedAccess.role}`
+  );
 
   return (
     <ChatPage

--- a/src/features/auth-page/auth-api.ts
+++ b/src/features/auth-page/auth-api.ts
@@ -3,8 +3,9 @@ import NextAuth, { NextAuthOptions } from "next-auth";
 import AzureADProvider from "next-auth/providers/azure-ad";
 import CredentialsProvider from "next-auth/providers/credentials";
 import GitHubProvider from "next-auth/providers/github";
-import type { Provider } from "next-auth/providers/index";
+import type { Provider } from "next-auth/providers/index";  // ← 修正
 import { hashValue } from "@/features/auth-page/helpers";
+import { getEffectiveSlUserEmail, resolveSlAccess } from "@/lib/sl-dept";
 
 const AAD_SCOPE = [
   "openid",
@@ -15,12 +16,22 @@ const AAD_SCOPE = [
   "Files.ReadWrite",
 ].join(" ");
 
+function resolveLocalDevEmail(username?: string | null): string {
+  const fallbackUsername = (username ?? "dev").trim() || "dev";
+  return (
+    process.env.SL_LOCAL_DEFAULT_EMAIL ??
+    process.env.NEXT_PUBLIC_DEV_USER_EMAIL ??
+    `${fallbackUsername}@localhost`
+  );
+}
+
 const configureIdentityProvider = () => {
   const providers: Array<Provider> = [];
 
-  const adminEmails = process.env.ADMIN_EMAIL_ADDRESS
-    ?.split(",")
-    .map((email) => email.toLowerCase().trim());
+  const adminEmails = [
+    ...(process.env.SL_ADMIN_EMAILS?.split(",").map((e) => e.toLowerCase().trim()).filter(Boolean) ?? []),
+    ...(process.env.ADMIN_EMAIL_ADDRESS?.split(",").map((e) => e.toLowerCase().trim()).filter(Boolean) ?? []),
+  ];
 
   if (process.env.AUTH_GITHUB_ID && process.env.AUTH_GITHUB_SECRET) {
     providers.push(
@@ -76,12 +87,17 @@ const configureIdentityProvider = () => {
         },
         async authorize(credentials) {
           const username = credentials?.username || "dev";
-          const email = `${username}@localhost`;
+          // NEXT_PUBLIC_DEV_USER_EMAIL が設定されていればそのメールを使う（SL ロール判定のため）
+          const email = resolveLocalDevEmail(username);
+          const adminEmails = [
+            ...(process.env.SL_ADMIN_EMAILS?.split(",").map((e) => e.toLowerCase().trim()).filter(Boolean) ?? []),
+            ...(process.env.ADMIN_EMAIL_ADDRESS?.split(",").map((e) => e.toLowerCase().trim()).filter(Boolean) ?? []),
+          ];
           const user = {
             id: hashValue(email),
             name: username,
             email,
-            isAdmin: false,
+            isAdmin: adminEmails.includes(email.toLowerCase()),
             image: "",
           };
           console.log("=== DEV USER LOGGED IN ===\n", JSON.stringify(user, null, 2));
@@ -139,7 +155,6 @@ async function refreshAzureADAccessToken(token: any) {
   }
 }
 
-// ✅ options のみ export（NextAuth の呼び出しは route.ts で行う）
 export const options: NextAuthOptions = {
   secret: process.env.NEXTAUTH_SECRET,
   providers: [...configureIdentityProvider()],
@@ -151,6 +166,18 @@ export const options: NextAuthOptions = {
         token.email = (user as any).email ?? token.email;
         token.name = (user as any).name ?? token.name;
         (token as any).picture = (user as any).image ?? (token as any).picture;
+
+        // ★ SlRole / SlDept をトークンに保存（サインイン時に1回計算）
+        try {
+          const emailForRole = getEffectiveSlUserEmail(
+            String((user as any).email ?? token.email ?? "")
+          );
+          const access = resolveSlAccess(emailForRole);
+          (token as any).slRole = access.role;
+          (token as any).slDept = access.dept;
+        } catch {
+          // SL_DEPTS / SL_DEPT_DEFAULT 未設定時はスキップ（バッジ非表示）
+        }
       }
 
       const p: any = profile ?? {};
@@ -185,6 +212,8 @@ export const options: NextAuthOptions = {
         session.user.email = token.email as string;
         session.user.name = token.name as string;
         (session.user as any).image = (token as any).picture as string;
+        session.user.slRole = (token as any).slRole;
+        session.user.slDept = (token as any).slDept;
       }
       (session as any).accessToken = (token as any).accessToken;
       (session as any).accessTokenExpiresAt = (token as any).accessTokenExpiresAt;
@@ -192,9 +221,7 @@ export const options: NextAuthOptions = {
       return session;
     },
   },
-
   session: {
     strategy: "jwt",
   },
 };
-// ↑ ここで終わり。末尾の export const { auth } = NextAuth(options); は削除済み

--- a/src/features/auth-page/helpers.ts
+++ b/src/features/auth-page/helpers.ts
@@ -11,6 +11,8 @@ export const userSession = async (): Promise<UserModel | null> => {
       image: session.user.image!,
       email: session.user.email!,
       isAdmin: session.user.isAdmin!,
+      slRole: session.user.slRole,
+      slDept: session.user.slDept,
     };
   }
 
@@ -36,7 +38,7 @@ export const userHashedId = async (): Promise<string> => {
 
 export const hashValue = (value: string): string => {
   const hash = createHash("sha256");
-  hash.update(value);
+  hash.update(value.trim().toLowerCase());
   return hash.digest("hex");
 };
 
@@ -52,4 +54,6 @@ export type UserModel = {
   image: string;
   email: string;
   isAdmin: boolean;
+  slRole?: "global_admin" | "dept_admin" | "dept_member";
+  slDept?: string;
 };

--- a/src/features/auth-page/login.tsx
+++ b/src/features/auth-page/login.tsx
@@ -22,7 +22,7 @@ export const LogIn: FC<LoginProps> = (props) => {
       <CardHeader className="gap-2">
         <CardTitle className="text-2xl flex gap-2">
           <Avatar className="h-8 w-8">
-            <AvatarImage src={"ai-icon.png"} />
+            <AvatarImage src={"/ai-icon.png"} />
           </Avatar>
           <span className="text-primary">{AI_NAME}</span>
         </CardTitle>

--- a/src/features/chat-page/chat-header/chat-header.tsx
+++ b/src/features/chat-page/chat-header/chat-header.tsx
@@ -1,7 +1,8 @@
 "use client";
+
 import { ExtensionModel } from "@/features/extensions-page/extension-services/models";
 import { CHAT_DEFAULT_PERSONA } from "@/features/theme/theme-config";
-import { VenetianMask, RefreshCw } from "lucide-react";
+import { RefreshCw, VenetianMask } from "lucide-react";
 import { FC, useState } from "react";
 import { ChatDocumentModel, ChatThreadModel } from "../chat-services/models";
 import { DocumentDetail } from "./document-detail";
@@ -12,8 +13,15 @@ interface Props {
   chatThread: ChatThreadModel;
   chatDocuments: Array<ChatDocumentModel>;
   extensions: Array<ExtensionModel>;
-  isAdmin?: boolean; // 管理者のみ同期ボタンを表示
+  isAdmin?: boolean;
 }
+
+type SyncRow = {
+  deleted?: number;
+  error?: string;
+  skipped?: string;
+  urlUpdated?: number;
+};
 
 export const ChatHeader: FC<Props> = (props) => {
   const [syncing, setSyncing] = useState(false);
@@ -28,28 +36,53 @@ export const ChatHeader: FC<Props> = (props) => {
   const handleSync = async () => {
     setSyncing(true);
     setSyncResult(null);
+
     try {
-      const res = await fetch("/api/sl/sync-check", {
+      const res = await fetch("/api/sl/sync-check?apply=true", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: "{}",
       });
+
       const data = await res.json();
       if (data.ok) {
-        // 削除件数の合計を集計
-        const total = Object.values(data.results as Record<string, any>)
-          .filter((r) => !r.error)
-          .reduce((sum, r) => sum + (r.deleted ?? 0), 0);
-        setSyncResult(`✅ 同期完了（${total}件削除）`);
+        const allRows = Object.entries(data.results as Record<string, SyncRow>);
+        const errorDepts = allRows
+          .filter(([, row]) => row.error)
+          .map(([dept]) => dept);
+        const skippedDepts = allRows
+          .filter(([, row]) => row.skipped)
+          .map(([dept, row]) => `${dept}:${row.skipped}`);
+        const okRows = allRows
+          .filter(([, row]) => !row.error)
+          .map(([, row]) => row);
+
+        const updated = okRows.reduce(
+          (sum, row) => sum + (row.urlUpdated ?? 0),
+          0
+        );
+        const deleted = okRows.reduce(
+          (sum, row) => sum + (row.deleted ?? 0),
+          0
+        );
+
+        const parts = [`更新:${updated}件`, `削除:${deleted}件`];
+        if (errorDepts.length > 0) {
+          parts.push(`エラー:${errorDepts.join(",")}`);
+        }
+        if (skippedDepts.length > 0) {
+          parts.push(`スキップ:${skippedDepts.join(",")}`);
+        }
+
+        setSyncResult(parts.join(" "));
       } else {
-        setSyncResult(`❌ エラー: ${data.error}`);
+        setSyncResult(`エラー: ${data.error}`);
       }
     } catch (e: any) {
-      setSyncResult(`❌ エラー: ${e.message}`);
+      setSyncResult(`エラー: ${e.message}`);
     } finally {
       setSyncing(false);
-      // 3秒後にメッセージを消す
-      setTimeout(() => setSyncResult(null), 3000);
+      setTimeout(() => setSyncResult(null), 5000);
     }
   };
 
@@ -64,7 +97,6 @@ export const ChatHeader: FC<Props> = (props) => {
           </span>
         </div>
         <div className="flex gap-2 items-center">
-          {/* 管理者のみIndex同期ボタンを表示 */}
           {props.isAdmin && (
             <div className="flex items-center gap-2">
               {syncResult && (

--- a/src/features/chat-page/chat-input/chat-input.tsx
+++ b/src/features/chat-page/chat-input/chat-input.tsx
@@ -33,13 +33,9 @@ import {
   useTextToSpeech,
 } from "./speech/use-text-to-speech";
 
-// ★ 思考モードトグル（3段階：標準→熟考→即答）
-//import {
-//ModeCycleButton,
-//type ThinkingMode,
-//} from "@/components/chatModeToggle";
+type UploadScope = "common" | "personal";
 
-export const ChatInput = () => {
+export const ChatInput = ({ isAdmin: isAdminProp }: { isAdmin?: boolean }) => {
   const { loading, input, chatThreadId } = useChat();
   const { uploadButtonLabel } = useFileStore();
   const { isPlaying } = useTextToSpeech();
@@ -49,20 +45,13 @@ export const ChatInput = () => {
   const submitButton = React.useRef<HTMLButtonElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
 
-  // ★ モードは ChatInput 側で保持（hidden input で route に渡す）
   const mode = "standard";
 
-  // ★ 管理者判定
+  // ★ 管理者判定（セッションのisAdminを使用 - ビルド時env不要）
   const { data: session } = useSession();
-  const adminEmails = (process.env.NEXT_PUBLIC_SL_ADMIN_EMAILS ?? "")
-    .split(",")
-    .map((s) => s.trim().toLowerCase())
-    .filter(Boolean);
-  const me = (session?.user as any)?.email?.toLowerCase?.() ?? "";
-  const isAdmin = adminEmails.includes(me);
+  const isAdmin = isAdminProp ?? Boolean((session?.user as any)?.isAdmin);
 
-
-  const [uploadTarget, setUploadTarget] = useState<"cp" | "common" | "others">("cp");
+  const [uploadScope, setUploadScope] = useState<UploadScope>("personal");
 
   const submit = () => {
     if (formRef.current) {
@@ -79,7 +68,6 @@ export const ChatInput = () => {
       }}
       status={uploadButtonLabel}
     >
-      {/* ★ サーバに確実に届くよう hidden input を同送 */}
       <input type="hidden" name="thinkingMode" value={mode} />
 
       <ChatTextInput
@@ -108,35 +96,40 @@ export const ChatInput = () => {
               fileStore.onFileChange({
                 formData,
                 chatThreadId,
-                dept: isAdmin ? uploadTarget : undefined,
+                uploadScope: isAdmin ? uploadScope : undefined,
               })
             }
           />
+
           <PromptSlider />
 
-          {/* ★ 管理者のみ：アップロード先トグル */}
+          {/* ★ 管理者のみ：アップロード先トグル（共通 / 個人） */}
           {isAdmin && (
             <div className="flex items-center gap-1 text-xs text-muted-foreground">
               <span>UP先:</span>
-              {(["cp", "common", "others"] as const).map((t) => (
+
+              {(
+                [
+                  { value: "common" as const, label: "共通" },
+                  { value: "personal" as const, label: "個人" },
+                ] as const
+              ).map((item) => (
                 <button
-                  key={t}
+                  key={item.value}
                   type="button"
-                  onClick={() => setUploadTarget(t)}
+                  onClick={() => setUploadScope(item.value)}
                   className={`px-2 py-0.5 rounded border text-xs transition-colors ${
-                    uploadTarget === t
+                    uploadScope === item.value
                       ? "bg-primary text-primary-foreground border-primary"
                       : "border-muted-foreground hover:bg-muted"
                   }`}
+                  aria-pressed={uploadScope === item.value}
                 >
-                  {t.toUpperCase()}
+                  {item.label}
                 </button>
               ))}
             </div>
           )}
-
-          {/* ★ 思考モードトグル（標準→熟考→即答→…） */}
-          {/*<ModeCycleButton value={mode} onChange={setMode} />*/}
         </ChatInputSecondaryActionArea>
 
         <ChatInputPrimaryActionArea>

--- a/src/features/chat-page/chat-input/file/file-store.ts
+++ b/src/features/chat-page/chat-input/file/file-store.ts
@@ -25,41 +25,41 @@ async function fileToBase64(file: File): Promise<string> {
   });
 }
 
-function normalizeDept(value?: string | null): string {
-  const d = (value ?? "").toLowerCase().trim();
-  return d || "cp";
+type UploadScope = "common" | "personal";
+
+/**
+ * uploadScope の正規化
+ * - common / personal を正式値とする
+ * - 旧値 cp は personal として吸収
+ * - 未指定も personal 扱い
+ */
+function normalizeUploadScope(value?: string | null): UploadScope {
+  const v = (value ?? "").toLowerCase().trim();
+
+  if (v === "common") return "common";
+  if (v === "personal") return "personal";
+  if (v === "cp") return "personal";
+
+  return "personal";
 }
 
 /**
- * アップロード先 dept の決定
- * 優先順位: props.dept（トグル選択） > NEXT_PUBLIC_SL_DEPT（従来） > "cp"
+ * フロント側の希望 uploadScope
+ * 優先順位:
+ * 1) props.uploadScope
+ * 2) 旧 env 値（互換）
+ * 3) personal
  */
-function resolveUploadDept(propsDept?: string): string {
-  const fromProps = normalizeDept(propsDept);
-  if (propsDept && fromProps) return fromProps;
+function resolveRequestedUploadScope(propsUploadScope?: string): UploadScope {
+  const fromProps = normalizeUploadScope(propsUploadScope);
+  if (propsUploadScope) return fromProps;
 
-  const fromEnv = normalizeDept(process.env.NEXT_PUBLIC_SL_DEPT);
-  return fromEnv || "cp";
+  const fromEnv = normalizeUploadScope(process.env.NEXT_PUBLIC_SL_DEPT);
+  return fromEnv;
 }
 
-/**
- * SL文書かどうかの判定
- * NEXT_PUBLIC_SL_DEPT_NON_SP に設定された dept は SP未対応 → isSlDoc=false
- * それ以外は SP対応部署 → isSlDoc=true
- */
-function resolveIsSlDoc(uploadDept: string): boolean {
-  const nonSpDept = (process.env.NEXT_PUBLIC_SL_DEPT_NON_SP ?? "others")
-    .toLowerCase()
-    .trim();
-  return uploadDept !== nonSpDept;
-}
-
-// SharePointへ同期コピー
-// 戻り値: null = SL無効（スキップ）, オブジェクト = 成功, throw = エラー
-async function publishToSharePoint(
-  file: File,
-  dept: string
-): Promise<{ ok: true; dept?: string; webUrl?: string; name?: string } | null> {
+// SharePointへ同期コピー（失敗したらthrow）
+async function publishToSharePoint(file: File, uploadScope: UploadScope) {
   const fileBase64 = await fileToBase64(file);
 
   const r = await fetch("/api/sl/publish", {
@@ -68,29 +68,26 @@ async function publishToSharePoint(
     body: JSON.stringify({
       fileName: file.name,
       fileBase64,
-      dept,
+      uploadScope,
     }),
   });
-
-  // ★ SL無効時（NEXT_PUBLIC_SL_ENABLED=false）はサーバが404を返す
-  // → エラーにせずnullを返してスキップ
-  if (r.status === 404) {
-    console.log("[SL] publish disabled, skipping SharePoint sync");
-    return null;
-  }
 
   const json = await r.json().catch(() => ({}));
 
   if (!r.ok || !json?.ok) {
-    const msg = json?.error || `SharePoint publish failed (status=${r.status})`;
+    const msg =
+      json?.error || `SharePoint publish failed (status=${r.status})`;
     throw new Error(msg);
   }
 
   return json as {
     ok: true;
     dept?: string;
+    uploadScope?: UploadScope;
+    isSharePointEnabled?: boolean;
     webUrl?: string;
     name?: string;
+    spItemId?: string | null;
   };
 }
 
@@ -100,9 +97,9 @@ class FileStore {
   public async onFileChange(props: {
     formData: FormData;
     chatThreadId: string;
-    dept?: string;
+    uploadScope?: string; // トグルから渡す
   }) {
-    const { formData, chatThreadId, dept: requestedDept } = props;
+    const { formData, chatThreadId, uploadScope: requestedScopeRaw } = props;
 
     try {
       chatStore.updateLoading("file upload");
@@ -115,8 +112,8 @@ class FileStore {
         return;
       }
 
-      const requestedUploadDept = resolveUploadDept(requestedDept);
-      const requestedIsSlDoc = resolveIsSlDoc(requestedUploadDept);
+      // フロント側の希望値（最終決定はサーバ側）
+      const requestedUploadScope = resolveRequestedUploadScope(requestedScopeRaw);
 
       this.uploadButtonLabel = "Processing document";
       formData.append("fileName", file.name);
@@ -125,61 +122,88 @@ class FileStore {
       const crackingResponse = await CrackDocument(formData);
 
       if (crackingResponse.status === "OK" && uploadResponse.status === "OK") {
-        let actualDept = requestedUploadDept;
-        let actualIsSlDoc = requestedIsSlDoc;
-        let sp:
-          | { ok: true; dept?: string; webUrl?: string; name?: string }
-          | null
-          | undefined;
+        let actualDept = "";
+        let actualIsSlDoc = false;
+        let actualUploadScope: UploadScope = requestedUploadScope;
+        // ★ SP webUrl を保持する変数（SPアップ成功時のみ設定される）
+        let spWebUrl: string | undefined;
+        // ★ SP item ID（移動後もindexと紐付けるための不変ID）
+        let spItemId: string | null = null;
 
-        if (requestedIsSlDoc) {
-          try {
-            this.uploadButtonLabel = "Syncing to SharePoint";
-            sp = await publishToSharePoint(file, requestedUploadDept);
+        try {
+          this.uploadButtonLabel = "Syncing to SharePoint";
 
-            if (sp === null) {
-              // ★ SL無効 → SP syncスキップ、通常indexingへ
-              actualDept = requestedUploadDept;
-              actualIsSlDoc = false;
-              console.log("[SL] SP sync skipped (disabled). Proceeding with normal indexing.");
-            } else {
-              // SP sync成功
-              actualDept = normalizeDept(sp.dept || requestedUploadDept);
-              actualIsSlDoc = resolveIsSlDoc(actualDept);
+          const sp = await publishToSharePoint(file, requestedUploadScope);
 
-              showSuccess({
-                title: "SharePoint sync",
-                description: sp.webUrl
-                  ? `Synced to SharePoint (${actualDept}): ${sp.webUrl}`
-                  : `Synced to SharePoint (${actualDept}): ${sp.name || file.name}`,
-              });
-            }
-          } catch (e: any) {
-            showError(
-              `SharePoint sync failed (index skipped): ${String(
-                e?.message ?? e
-              )}`
-            );
+          // ★ SP webUrl を取得（Index の fileUrl に使う）
+          if (sp.isSharePointEnabled === true && !sp.webUrl) {
+            throw new Error("SharePoint publish succeeded but webUrl was empty.");
+          }
+          spWebUrl = sp.webUrl;
+          spItemId = sp.spItemId ?? null;
+          actualDept = String(sp.dept ?? "").toLowerCase().trim();
+          actualUploadScope = normalizeUploadScope(
+            sp.uploadScope ?? requestedUploadScope
+          );
+          actualIsSlDoc = sp.isSharePointEnabled === true;
+
+          showSuccess({
+            title: "SharePoint sync",
+            description: sp.webUrl
+              ? `Synced to SharePoint (${actualDept || "unknown"} / ${actualUploadScope}): ${sp.webUrl}`
+              : `Synced to SharePoint (${actualDept || "unknown"} / ${actualUploadScope}): ${sp.name || file.name}`,
+          });
+        } catch (e: any) {
+          const msg = String(e?.message ?? e);
+
+          // SP非対応部署は新仕様上ありうる
+          if (
+            msg.includes("not SharePoint-enabled") ||
+            msg.includes("Use Blob upload flow instead")
+          ) {
+            showSuccess({
+              title: "Blob upload",
+              description:
+                `${file.name} uploaded to Blob. ` +
+                `This department is not SharePoint-enabled, so SharePoint sync was skipped.`,
+            });
+
+            // 従来どおり Blob インデックス用
+            actualDept = (
+              process.env.NEXT_PUBLIC_SL_DEPT_NON_SP ?? "others"
+            ).toLowerCase().trim();
+            actualIsSlDoc = false;
+            actualUploadScope = "personal";
+          } else {
+            showError(`SharePoint sync failed (index skipped): ${msg}`);
             return;
           }
         }
 
-        // SharePoint 確定後の dept で Index 作成
+        // SharePoint / Blob の最終状態確定後に Index 作成
         let index = 0;
         const documentIndexResponses: Array<ServerActionResponse<boolean>> = [];
+        const searchableFileUrl = spWebUrl ?? uploadResponse.response;
+        const effectiveFileUrl = spWebUrl ?? uploadResponse.response;
 
         for (const doc of crackingResponse.response) {
           this.uploadButtonLabel = `Indexing document [${index + 1}]/[${
             crackingResponse.response.length
           }]`;
 
+          // ★ SPアップ成功時は SP webUrl を使う。それ以外は従来通り Blob URL。
+          // SL documents use SP webUrl as fileUrl so that deleted SP files
+          // are no longer reachable, avoiding stale Blob links in search results.
           const indexResponses = await IndexDocuments(
             file.name,
-            uploadResponse.response,
+            searchableFileUrl,
             [doc],
             chatThreadId,
             actualDept,
-            actualIsSlDoc
+            actualIsSlDoc,
+            actualUploadScope,
+            effectiveFileUrl,
+            spItemId
           );
 
           documentIndexResponses.push(...indexResponses);

--- a/src/features/chat-page/chat-page.tsx
+++ b/src/features/chat-page/chat-page.tsx
@@ -22,19 +22,12 @@ interface ChatPageProps {
   chatThread: ChatThreadModel;
   chatDocuments: Array<ChatDocumentModel>;
   extensions: Array<ExtensionModel>;
-  isAdmin?: boolean; // ★ 追加
+  isAdmin: boolean; // ← 追加
 }
 
 // ChatMessageArea が受け取れるロール（UI 用）
 type ChatUiRole = "user" | "system" | "assistant" | "tool";
 
-/**
- * ChatMessageModel の role（ChatRole）を
- * UI 用のロールに正規化する。
- *
- * - "function" は UI では "assistant" として扱う
- * - それ以外はそのまま通す
- */
 function toUiRole(role: ChatMessageModel["role"]): ChatUiRole {
   if (role === "function") {
     return "assistant";
@@ -45,13 +38,8 @@ function toUiRole(role: ChatMessageModel["role"]): ChatUiRole {
 export const ChatPage: FC<ChatPageProps> = (props) => {
   const { data: session } = useSession();
 
-  // ★ 管理者判定
-  const adminEmails = (process.env.NEXT_PUBLIC_SL_ADMIN_EMAILS ?? "")
-    .split(",")
-    .map((s) => s.trim().toLowerCase())
-    .filter(Boolean);
-  const me = (session?.user as any)?.email?.toLowerCase?.() ?? "";
-  const isAdmin = adminEmails.includes(me);
+  // Server Component 側で確定済みの isAdmin を使う
+  const isAdmin = props.isAdmin;
 
   useEffect(() => {
     chatStore.initChatSession({
@@ -73,7 +61,7 @@ export const ChatPage: FC<ChatPageProps> = (props) => {
         chatThread={props.chatThread}
         chatDocuments={props.chatDocuments}
         extensions={props.extensions}
-        isAdmin={isAdmin} // ★ 追加
+        isAdmin={isAdmin}
       />
       <ChatMessageContainer ref={current}>
         <ChatMessageContentArea>
@@ -99,7 +87,7 @@ export const ChatPage: FC<ChatPageProps> = (props) => {
           {loading === "loading" && <ChatLoading />}
         </ChatMessageContentArea>
       </ChatMessageContainer>
-      <ChatInput />
+      <ChatInput isAdmin={isAdmin} />
     </main>
   );
 };

--- a/src/features/chat-page/chat-services/azure-ai-search/azure-ai-search.ts
+++ b/src/features/chat-page/chat-services/azure-ai-search/azure-ai-search.ts
@@ -1,7 +1,7 @@
 "use server";
 import "server-only";
-
 import { userHashedId } from "@/features/auth-page/helpers";
+import { isSharePointEnabledDept } from "@/lib/sl-dept";
 import { ServerActionResponse } from "@/features/common/server-action-response";
 import {
   AzureAISearchIndexClientInstance,
@@ -23,8 +23,13 @@ export interface AzureSearchDocumentIndex {
   chatThreadId: string;
   metadata: string;
   fileUrl: string;
+  effectiveFileUrl?: string | null;
   dept: string;
   isSlDoc: boolean | null;
+  slScope?: "global_common" | "dept_common" | "personal" | null;
+  slOwner?: string | null;
+  /** SharePoint drive item ID。ファイル移動後もIDは不変のため、sync時の追跡に使用 */
+  spItemId?: string | null;
 }
 
 export type DocumentSearchResponse = {
@@ -43,19 +48,42 @@ function combineFilters(a?: string, b?: string): string | undefined {
   if (!aa) return bb || undefined;
   if (!bb) return aa || undefined;
 
-  return `(${aa}) and (${bb})`;
+  const combined = `(${aa}) and (${bb})`;
+  console.log("[SEARCH] combineFilters base =", aa || "(none)");
+  console.log("[SEARCH] combineFilters acl =", bb || "(none)");
+  console.log("[SEARCH] combineFilters result =", combined);
+  return combined;
+}
+
+type UploadScope = "global_common" | "dept_common" | "personal";
+
+function normalizeUploadScope(value?: string | null): UploadScope {
+  const v = (value ?? "").toLowerCase().trim();
+
+  if (v === "global_common") return "global_common";
+  if (v === "dept_common") return "dept_common";
+  if (v === "personal") return "personal";
+
+  // 旧値互換
+  if (v === "common") return "dept_common";
+  if (v === "cp") return "personal";
+
+  return "personal";
 }
 
 /**
- * ACL統一関数
- * - 個人文書: isSlDoc != true かつ user一致
- * - SL文書  : isSlDoc == true かつ dept一致 or common
+ * ACL統一関数（3Scope版）
  *
- * 使い分け:
- * - deptLower === null      → ACLを付けない（明示的無効化）
- * - deptLower === undefined → fallbackで "others"
- * - userHash が渡された場合はそれを使う（Route Handler経由）
- * - userHash が未指定の場合は userHashedId() を呼ぶ（Server Action経由）
+ * 非SL文書:
+ *   isSlDoc != true and user == 自分
+ *
+ * SL文書:
+ *   global_common : 全員
+ *   dept_common   : 自部署
+ *   personal      : 自部署 + 自分
+ *
+ * 旧SL文書互換:
+ *   slScope/slOwner 未設定なら dept一致で暫定許可
  */
 async function buildSearchAclFilter(
   deptLower?: string | null,
@@ -64,14 +92,49 @@ async function buildSearchAclFilter(
   if (deptLower === null) return undefined;
 
   const normalizedDept = (deptLower ?? "others").toLowerCase().trim();
-  const d = escapeODataValue(normalizedDept);
+  console.log("[ACL] buildSearchAclFilter called, normalizedDept =", normalizedDept);
 
   const resolvedUserHash = userHash ?? (await userHashedId());
+  const u = escapeODataValue(resolvedUserHash);
 
-  const userFilter = `(isSlDoc ne true and user eq '${escapeODataValue(resolvedUserHash)}')`;
-  const deptFilter = `(isSlDoc eq true and (dept eq '${d}' or dept eq 'common'))`;
+  // 非SP部署（others等）は自分のBlobと全社共通SL文書のみ
+  if (!isSharePointEnabledDept(normalizedDept)) {
+    console.log("[ACL] non-SP dept, only personal Blob + global_common:", normalizedDept);
+    return `((isSlDoc ne true and user eq '${u}') or (isSlDoc eq true and slScope eq 'global_common'))`;
+  }
 
-  return `(${userFilter} or ${deptFilter})`;
+  const d = escapeODataValue(normalizedDept);
+
+  const slGlobalCommonFilter =
+    `(isSlDoc eq true and slScope eq 'global_common')`;
+
+  const slDeptCommonFilter =
+    `(isSlDoc eq true and dept eq '${d}' and slScope eq 'dept_common')`;
+
+  const slPersonalFilter =
+    `(isSlDoc eq true and dept eq '${d}' and slScope eq 'personal' and slOwner eq '${u}')`;
+
+  const slLegacyFilter =
+    `(isSlDoc eq true and dept eq '${d}' and (slScope eq null or slScope eq '' or (slScope eq 'personal' and slOwner eq null)))`;
+
+  console.log("[ACL] resolvedUserHash =", resolvedUserHash);
+  console.log("[ACL] normalizedDept =", normalizedDept);
+  console.log("[ACL] slGlobalCommonFilter =", slGlobalCommonFilter);
+  console.log("[ACL] slDeptCommonFilter =", slDeptCommonFilter);
+  console.log("[ACL] slPersonalFilter =", slPersonalFilter);
+  console.log("[ACL] slLegacyFilter =", slLegacyFilter);
+
+  // 自分自身がアップした非SL Blob文書（isSlDoc=false, user=自分）も常に含める。
+  // SP対応部署でも global_admin のような部署メアドなしユーザーが Blob アップした場合に対応。
+  const blobOwnFilter = `(isSlDoc ne true and user eq '${u}')`;
+
+  const finalAcl = `(${slGlobalCommonFilter} or ${slDeptCommonFilter} or ${slPersonalFilter} or ${slLegacyFilter} or ${blobOwnFilter})`;
+    console.log("[ACL] FINAL FILTER =", finalAcl);
+    return finalAcl;
+
+  
+
+  
 }
 
 // -------------------------------------------------------
@@ -81,7 +144,8 @@ async function buildSearchAclFilter(
 export const SimpleSearch = async (
   searchText?: string,
   filter?: string,
-  deptLower?: string | null
+  deptLower?: string | null,
+  top?: number
 ): Promise<ServerActionResponse<Array<DocumentSearchResponse>>> => {
   try {
     const instance = AzureAISearchInstance<AzureSearchDocumentIndex>();
@@ -91,6 +155,7 @@ export const SimpleSearch = async (
 
     const searchResults = await instance.search(searchText ?? "*", {
       filter: finalFilter,
+      ...(top !== undefined ? { top } : {}),
     });
 
     const results: Array<DocumentSearchResponse> = [];
@@ -165,7 +230,7 @@ export const ExtensionSimilaritySearch = async (props: {
   indexName: string;
   filter?: string;
   deptLower?: string | null;
-  userHash?: string; // Route Handler経由で渡すuserHash
+  userHash?: string;
 }): Promise<ServerActionResponse<Array<DocumentSearchResponse>>> => {
   try {
     const openai = OpenAIEmbeddingInstance();
@@ -195,10 +260,11 @@ export const ExtensionSimilaritySearch = async (props: {
       { allowInsecureConnection: process.env.NODE_ENV === "development" }
     );
 
-    // userHash を外から受け取り buildSearchAclFilter に渡す
     const scopeFilter = await buildSearchAclFilter(deptLower, userHash);
     const finalFilter = combineFilters(filter, scopeFilter);
 
+    console.log("[SEARCH:Extension] inputFilter =", filter ?? "(none)");
+    console.log("[SEARCH:Extension] scopeFilter =", scopeFilter ?? "(none)");
     console.log("[SEARCH:Extension] deptLower =", deptLower);
     console.log("[SEARCH:Extension] userHash =", userHash ? "***" : "(none)");
     console.log("[SEARCH:Extension] finalFilter =", finalFilter);
@@ -252,11 +318,18 @@ export const IndexDocuments = async (
   docs: string[],
   chatThreadId: string,
   dept: string,
-  isSlDoc: boolean
+  isSlDoc: boolean,
+  uploadScope?: string,
+  effectiveFileUrl?: string,
+  spItemId?: string | null
 ): Promise<Array<ServerActionResponse<boolean>>> => {
   try {
     const documentsToIndex: AzureSearchDocumentIndex[] = [];
     const currentUserHash = await userHashedId();
+    const normalizedDept = (dept ?? "others").toLowerCase().trim();
+    // "common" dept は global_admin が全社共有 SP にアップしたもの → global_common 扱い
+    const normalizedScope =
+      normalizedDept === "common" ? "global_common" : normalizeUploadScope(uploadScope);
 
     for (const doc of docs) {
       documentsToIndex.push({
@@ -266,9 +339,14 @@ export const IndexDocuments = async (
         pageContent: doc,
         metadata: fileName,
         fileUrl,
+        effectiveFileUrl: effectiveFileUrl ?? fileUrl,
         embedding: [],
-        dept: (dept ?? "others").toLowerCase().trim(),
+        dept: normalizedDept,
         isSlDoc,
+        slScope: isSlDoc ? normalizedScope : null,
+        slOwner:
+          isSlDoc && normalizedScope === "personal" ? currentUserHash : null,
+        spItemId: spItemId ?? null,
       });
     }
 

--- a/src/features/chat-page/chat-services/chat-api/chat-api-dynamic-extensions.ts
+++ b/src/features/chat-page/chat-services/chat-api/chat-api-dynamic-extensions.ts
@@ -2,7 +2,7 @@
 import "server-only";
 
 import { ServerActionResponse } from "@/features/common/server-action-response";
-import { userHashedId } from "@/features/auth-page/helpers";
+import { userHashedId, userSession } from "@/features/auth-page/helpers";
 import {
   FindAllExtensionForCurrentUser,
   FindSecureHeaderValue,
@@ -23,18 +23,16 @@ function looksJsonContentType(ct?: string | null) {
 
 async function parseJsonSafe(res: Response): Promise<any> {
   const ct = res.headers.get("content-type");
-  const raw = await res.text(); // 先にテキストで読む（デバッグしやすさ優先）
+  const raw = await res.text();
   if (looksJsonContentType(ct)) {
     try {
       return JSON.parse(raw);
     } catch (e) {
-      // JSON宣言だが壊れている
       throw new Error(
         `Failed to parse JSON (declared as JSON). ParseError=${(e as Error).message}. BodySnippet=${raw.slice(0, 500)}`
       );
     }
   }
-  // JSON以外（HTMLなど）
   throw new Error(
     `Non-JSON response. Content-Type="${ct ?? "unknown"}". BodySnippet=${raw
       .replace(/\s+/g, " ")
@@ -108,26 +106,38 @@ async function executeFunction(props: {
       value: await userHashedId(),
     });
 
-    // 3) ヘッダ辞書化
+    // 3) ログインユーザーのemailをヘッダーに付与
+    const currentUser = await userSession().catch(() => null);
+    const loginEmail = currentUser?.email ?? "";
+    if (loginEmail) {
+      headerItems.push({
+        id: "x-user-email",
+        key: "x-user-email",
+        value: loginEmail,
+      });
+      console.log("[EXT] Attaching x-user-email:", loginEmail);
+    } else {
+      console.log("[EXT] x-user-email not available");
+    }
+
+    // 4) ヘッダ辞書化
     const headers: Record<string, string> = headerItems.reduce(
       (acc, h) => ((acc[h.key] = h.value), acc),
       {} as Record<string, string>
     );
 
-    // 4) クエリ置換（エンドポイント文字列をコピーしてから置換）
+    // 5) クエリ置換
     let endpoint = functionModel.endpoint;
     if (args?.query && typeof args.query === "object") {
       for (const key of Object.keys(args.query)) {
-        // {city} のようなテンプレートを想定： "…?q={city}" -> 値に置換
         const val = String(args.query[key] ?? "");
         const safe = encodeURIComponent(val);
         endpoint = endpoint.replace(new RegExp(`{${key}}`, "g"), safe);
-        // 後方互換：単純な key マッチにも対応（既存実装踏襲）
         endpoint = endpoint.replace(new RegExp(`${key}`, "g"), safe);
       }
     }
 
-    // 5) リクエスト構築
+    // 6) リクエスト構築
     const requestInit: RequestInit = {
       method: functionModel.endpointType,
       headers,
@@ -135,17 +145,16 @@ async function executeFunction(props: {
     };
     if (args?.body) {
       requestInit.body = JSON.stringify(args.body);
-      // JSON 送信であることを明示（既に付いているなら上書きしない）
       if (!Object.keys(headers).some((k) => k.toLowerCase() === "content-type")) {
         (requestInit.headers as Record<string, string>)["content-type"] =
           "application/json";
       }
     }
 
-    // 6) 呼び出し
+    // 7) 呼び出し
     const response = await fetch(endpoint, requestInit);
 
-    // 7) ステータスエラーは本文をスニペットで返す（HTMLでも可視化）
+    // 8) ステータスエラー
     if (!response.ok) {
       const ct = response.headers.get("content-type");
       const body = await response.text();
@@ -163,7 +172,6 @@ async function executeFunction(props: {
       return `There was an error calling the api: ${response.status} ${response.statusText}. URL=${endpoint}. Snippet=${hint}`;
     }
 
-    // 8) JSON以外の本文（HTMLなど）に対する保護：JSONとして読めなければ詳細を投げる
     const result = await parseJsonSafe(response);
 
     return {
@@ -171,7 +179,6 @@ async function executeFunction(props: {
       result,
     };
   } catch (e: any) {
-    // 9) ランタイム例外（<!DOCTYPE…>含む）を安全に文字列化
     const msg = e?.message || String(e);
     console.error("🔴 executeFunction error:", msg);
     return `There was an error calling the api: ${msg}`;

--- a/src/features/chat-page/chat-services/chat-api/chat-api-rag-extension.ts
+++ b/src/features/chat-page/chat-services/chat-api/chat-api-rag-extension.ts
@@ -1,102 +1,87 @@
-import { getToken } from "next-auth/jwt";
-import { decideDept, getUserEmailFromJwtToken } from "@/lib/sl-dept";
 import { ExtensionSimilaritySearch } from "../azure-ai-search/azure-ai-search";
 import { CreateCitations, FormatCitations } from "../citation-service";
 
-/**
- * Request から deptLower を解決
- * - next-auth token から email を取得
- * - token が無く、SL_LOCAL_EMAIL があれば Local 開発用に使用
- * - email -> decideDept()
- * - fallback は SL_DEPT_DEFAULT
- */
-async function resolveDeptLowerFromRequest(req: Request): Promise<string> {
-  try {
-    const cookieHeader = req.headers.get("cookie") ?? "";
-
-    const token = await getToken({
-      req: {
-        headers: {
-          cookie: cookieHeader,
-        },
-        cookies: Object.fromEntries(
-          cookieHeader
-            .split(";")
-            .map((part) => part.trim())
-            .filter(Boolean)
-            .map((part) => {
-              const eq = part.indexOf("=");
-              if (eq < 0) return [part, ""];
-              const key = part.slice(0, eq);
-              const value = part.slice(eq + 1);
-              return [key, value];
-            })
-        ),
-      } as any,
-      secret: process.env.NEXTAUTH_SECRET!,
-    }).catch(() => null);
-
-    let email = token ? getUserEmailFromJwtToken(token) : null;
-
-    if (!email && process.env.SL_LOCAL_EMAIL) {
-      email = process.env.SL_LOCAL_EMAIL;
-    }
-
-    return decideDept({
-      requestedDept: undefined,
-      userEmail: email,
-    });
-  } catch {
-    return (
-      (process.env.SL_DEPT_DEFAULT ?? "others").toLowerCase().trim() || "others"
-    );
+function getRequiredHeader(req: Request, name: string): string {
+  const value = req.headers.get(name)?.trim();
+  if (!value) {
+    throw new Error(`[EXT-RAG] Missing required header: ${name}`);
   }
+  return value;
 }
 
 export const SearchAzureAISimilarDocuments = async (
   req: Request,
-  deptLowerFromRoute?: string
+  deptLower: string,
+  userHash: string | null  // route.ts から受け取る
 ) => {
   try {
     const body = await req.json();
-    const search = body.search as string;
+    const search = String(body.search ?? "").trim();
 
-    const vectors = (req.headers.get("vectors") as string) ?? "";
-    const apiKey = (req.headers.get("apiKey") as string) ?? "";
-    const searchName = (req.headers.get("searchName") as string) ?? "";
-    const indexName = (req.headers.get("indexName") as string) ?? "";
+    if (!search) {
+      return new Response(
+        JSON.stringify({
+          status: "ERROR",
+          errors: [{ message: "Missing search text." }],
+        }),
+        {
+          headers: { "Content-Type": "application/json; charset=utf-8" },
+          status: 400,
+        }
+      );
+    }
 
-    // authorization header には userHash が入る想定
-    const userId = (req.headers.get("authorization") as string) ?? "";
+    if (!userHash) {
+      return new Response(
+        JSON.stringify({
+          status: "ERROR",
+          errors: [{ message: "User not authenticated." }],
+        }),
+        {
+          headers: { "Content-Type": "application/json; charset=utf-8" },
+          status: 401,
+        }
+      );
+    }
 
-    const deptLower =
-      deptLowerFromRoute ?? (await resolveDeptLowerFromRequest(req));
+    const vectorsHeader = getRequiredHeader(req, "vectors");
+    const apiKey = getRequiredHeader(req, "apiKey");
+    const searchName = getRequiredHeader(req, "searchName");
+    const indexName = getRequiredHeader(req, "indexName");
+
+    const vectors = vectorsHeader
+      .split(",")
+      .map((v) => v.trim())
+      .filter(Boolean);
 
     console.log("[EXT-RAG] deptLower =", deptLower);
+    console.log("[EXT-RAG] userHash =", userHash ? "***" : "(none)");
+    console.log("[EXT-RAG] searchName =", searchName);
+    console.log("[EXT-RAG] indexName =", indexName);
+    console.log("[EXT-RAG] vectors =", vectors);
 
     const result = await ExtensionSimilaritySearch({
       apiKey,
       searchName,
       indexName,
-      vectors: vectors
-        .split(",")
-        .map((v) => v.trim())
-        .filter(Boolean),
+      vectors,
       searchText: search,
       deptLower,
-      userHash: userId || undefined,
+      userHash,
     });
 
     if (result.status !== "OK") {
       console.error("🔴 Retrieving documents", result.errors);
+
       return new Response(JSON.stringify(result), {
         headers: { "Content-Type": "application/json; charset=utf-8" },
+        status: 500,
       });
     }
 
     const withoutEmbedding = FormatCitations(result.response);
 
-    const citationResponse = await CreateCitations(withoutEmbedding, userId);
+    const citationResponse = await CreateCitations(withoutEmbedding, userHash);
 
     const allCitations = [];
 
@@ -115,8 +100,15 @@ export const SearchAzureAISimilarDocuments = async (
   } catch (e) {
     console.error("🔴 Retrieving documents", e);
 
-    return new Response(JSON.stringify(e), {
-      headers: { "Content-Type": "application/json; charset=utf-8" },
-    });
+    return new Response(
+      JSON.stringify({
+        error: true,
+        message: e instanceof Error ? e.message : String(e),
+      }),
+      {
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+        status: 500,
+      }
+    );
   }
 };

--- a/src/features/chat-page/chat-services/chat-api/chat-api-rag.ts
+++ b/src/features/chat-page/chat-services/chat-api/chat-api-rag.ts
@@ -2,34 +2,42 @@
 import "server-only";
 
 import { OpenAIInstance } from "@/features/common/services/openai";
-import {
-  ChatCompletionStreamingRunner,
-  ChatCompletionStreamParams,
-} from "openai/resources/beta/chat/completions";
+import { ChatCompletionStreamingRunner } from "openai/resources/beta/chat/completions";
 import { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import { ExtensionSimilaritySearch } from "../azure-ai-search/azure-ai-search";
 import { CreateCitations, FormatCitations } from "../citation-service";
 import { ChatCitationModel, ChatThreadModel } from "../models";
+import { GetDefaultExtensions } from "./chat-api-default-extensions";
+import { FindAllChatDocuments } from "../chat-document-service";
+import { GenerateSasUrl } from "@/features/common/services/azure-storage";
 
 // dept判定ユーティリティ
-import { decideDept, getUserEmailFromJwtToken } from "@/lib/sl-dept";
+import { decideDept, getEffectiveSlUserEmail, getUserEmailFromJwtToken, resolveSlAccess } from "@/lib/sl-dept";
 import { getToken } from "next-auth/jwt";
 import { cookies } from "next/headers";
+import { hashValue, userSession } from "@/features/auth-page/helpers";
 
 // OData filter用にシングルクォートをエスケープ
 function odataEscape(v: string) {
   return String(v ?? "").replace(/'/g, "''");
 }
 
+type UserContext = {
+  email: string | null;
+  deptLower: string;
+  userHash: string | null;
+};
+
 /**
- * サーバ側で「ユーザーの deptLower」を決める
+ * サーバ側で「ユーザーの email / deptLower / userHash」を決める
  * - token から email を抜く
- * - token 無い場合は SL_LOCAL_EMAIL を使用（Local開発用）
  * - email → dept 判定（sl-dept.ts）
+ * - email → hashValue(email)
  * - fallback は SL_DEPT_DEFAULT
  */
-async function resolveDeptLower(): Promise<string> {
+async function resolveUserContext(): Promise<UserContext> {
   try {
+    const session = await userSession().catch(() => null);
     const cookieStore = await cookies();
 
     const token = await getToken({
@@ -44,27 +52,45 @@ async function resolveDeptLower(): Promise<string> {
       secret: process.env.NEXTAUTH_SECRET!,
     }).catch(() => null);
 
-    let email = token ? getUserEmailFromJwtToken(token) : null;
-
-    // ★ Local fallback
-    if (!email && process.env.SL_LOCAL_EMAIL) {
-      email = process.env.SL_LOCAL_EMAIL;
-    }
-
-    console.log("[DOC] email =", email);
-
-    return decideDept({
-      requestedDept: undefined,
-      userEmail: email,
-    });
-
-  } catch {
-
-    return (
-      (process.env.SL_DEPT_DEFAULT ?? "others")
-        .toLowerCase()
-        .trim() || "others"
+    const email = getEffectiveSlUserEmail(
+      token ? getUserEmailFromJwtToken(token) : null
     );
+
+    const deptLower = email
+      ? resolveSlAccess(email).dept
+      : session?.slDept?.trim().toLowerCase() ||
+        decideDept({
+          requestedDept: undefined,
+          userEmail: email,
+        });
+
+    const userHash = email ? hashValue(email) : null;
+
+    console.log("[RAG-EXT:resolveUserContext] email =", email);
+    console.log("[RAG-EXT:resolveUserContext] deptLower =", deptLower);
+    console.log(
+      "[RAG-EXT:resolveUserContext] userHash =",
+      userHash ? "***" : "(none)"
+    );
+
+    return {
+      email,
+      deptLower,
+      userHash,
+    };
+  } catch {
+    const deptLower =
+      (process.env.SL_DEPT_DEFAULT ?? "cp").toLowerCase().trim() || "cp";
+
+    console.log("[RAG-EXT:resolveUserContext] fallback email = (none)");
+    console.log("[RAG-EXT:resolveUserContext] fallback deptLower =", deptLower);
+    console.log("[RAG-EXT:resolveUserContext] fallback userHash = (none)");
+
+    return {
+      email: null,
+      deptLower,
+      userHash: null,
+    };
   }
 }
 
@@ -76,6 +102,22 @@ function getRequiredEnv(name: string): string {
   return value.trim();
 }
 
+async function resolveThreadDocumentBlobUrls(chatThreadId: string): Promise<string[]> {
+  const docsResponse = await FindAllChatDocuments(chatThreadId);
+  if (docsResponse.status !== "OK") {
+    return [];
+  }
+
+  const urls = await Promise.all(
+    docsResponse.response.map(async (doc) => {
+      const sas = await GenerateSasUrl("dl-link", `${chatThreadId}/${doc.name}`);
+      return sas.status === "OK" ? sas.response : null;
+    })
+  );
+
+  return Array.from(new Set(urls.filter((url): url is string => Boolean(url))));
+}
+
 export const ChatApiRAG = async (props: {
   chatThread: ChatThreadModel;
   userMessage: string;
@@ -85,13 +127,13 @@ export const ChatApiRAG = async (props: {
   const { chatThread, userMessage, history, signal } = props;
 
   const openAI = OpenAIInstance();
-  const deptLower = await resolveDeptLower();
+  const { email, deptLower, userHash } = await resolveUserContext();
 
+  console.log("[RAG-EXT] email =", email);
   console.log("[RAG-EXT] deptLower =", deptLower);
+  console.log("[RAG-EXT] userHash =", userHash ? "***" : "(none)");
 
-  // 業務条件は chatThreadId のみ
-  const filter = `chatThreadId eq '${odataEscape(chatThread.id)}'`;
-
+  const filter = `(chatThreadId eq '${odataEscape(chatThread.id)}' or isSlDoc eq true)`;
   console.log("[RAG-EXT] base filter =", filter);
 
   const apiKey = getRequiredEnv("AZURE_SEARCH_API_KEY");
@@ -106,39 +148,58 @@ export const ChatApiRAG = async (props: {
     indexName,
     filter,
     deptLower,
+    userHash: userHash ?? undefined,
   });
 
   const documents: ChatCitationModel[] = [];
+  const uploadedBlobUrls = await resolveThreadDocumentBlobUrls(chatThread.id);
 
   if (documentResponse.status === "OK") {
     const withoutEmbedding = FormatCitations(documentResponse.response);
     const citationResponse = await CreateCitations(withoutEmbedding);
-
     citationResponse.forEach((c) => {
       if (c.status === "OK") {
         documents.push(c.response);
       }
     });
   } else {
-    console.error(
-      "[RAG-EXT] ExtensionSimilaritySearch error:",
-      documentResponse.errors
-    );
+    console.error("[RAG-EXT] ExtensionSimilaritySearch error:", documentResponse.errors);
   }
 
   const content = documents
     .map((result, index) => {
       const page = result.content.document.pageContent;
+      const displayUrl =
+        result.content.document.effectiveFileUrl ??
+        result.content.document.fileUrl ??
+        "";
+      // このスレッドにアップロードされたファイルのみ file_url を出す
+      // 他スレッド由来のSLドキュメントは認証が必要なため除外（convert_doc_to_pptxで誤使用防止）
+      // SLファイルは fileUrl=SP webUrl / effectiveFileUrl=Blob URL なので、Blob URLを優先する
+      const isThisThread = result.content.document.chatThreadId === chatThread.id;
+      const blobUrl = isThisThread
+        ? (result.content.document.effectiveFileUrl ?? result.content.document.fileUrl ?? displayUrl)
+        : null;
       return `[${index}]. file name: ${result.content.document.metadata}
-file id: ${result.id}
+file id: ${result.id}${blobUrl ? `\nfile_url: ${blobUrl}` : ""}
 ${page}`;
     })
     .join("\n------\n");
+
+  // ファイルURLリスト（convert_doc_to_pptx ツールに渡すため）
+  // このスレッドにアップロードされたファイルのみを対象にする
+  const fileUrls = uploadedBlobUrls;
+  const hasUploadedFile = fileUrls.length > 0;
+
+  const fileUrlHint = hasUploadedFile
+    ? `\n- The uploaded document file URLs are:\n${fileUrls.map((u, i) => `  [${i}] ${u}`).join("\n")}\n- If the user asks to convert the document to PowerPoint, use the convert_doc_to_pptx tool with the file_url from above.`
+    : "\n- 【重要】このスレッドにアップロードされたファイルは存在しません。ユーザーがSharePoint/SLの資料名を挙げてPPT変換を要求した場合は、必ず convert_sp_to_pptx ツールを使うこと。convert_doc_to_pptx は使わないこと。";
 
   const _userMessage = `
 - Review the following content from documents uploaded by the user and create a final answer.
 - If you don't know the answer, just say that you don't know. Don't try to make up an answer.
 - You must always include a citation at the end of your answer and don't include full stop after the citations.
+- If the user asks to create a PowerPoint or slides from the document content, use the convert_doc_to_pptx tool with the file_url from the document context below. This tool uses Vision API for high-quality conversion.${fileUrlHint}
 
 ----------------
 content:
@@ -149,15 +210,41 @@ question:
 ${userMessage}
 `;
 
-  const stream: ChatCompletionStreamParams = {
-    model: "",
-    stream: true,
-    messages: [
-      { role: "system", content: chatThread.personaMessage },
-      ...history,
-      { role: "user", content: _userMessage },
-    ],
-  };
+  // ★ デフォルトツール（create_pptx 等）を RAG モードでも有効にする
+  const extensionsResponse = await GetDefaultExtensions({
+    chatThread,
+    userMessage,
+    signal,
+  });
+  const tools = extensionsResponse.status === "OK" ? extensionsResponse.response : [];
 
-  return openAI.beta.chat.completions.stream(stream, { signal });
+  if (tools.length > 0) {
+    return openAI.beta.chat.completions.runTools(
+      {
+        model: "",
+        stream: true,
+        messages: [
+          { role: "system", content: chatThread.personaMessage },
+          ...history,
+          { role: "user", content: _userMessage },
+        ],
+        tools,
+      },
+      { signal }
+    );
+  }
+
+  // ツールなしフォールバック
+  return openAI.beta.chat.completions.stream(
+    {
+      model: "",
+      stream: true,
+      messages: [
+        { role: "system", content: chatThread.personaMessage },
+        ...history,
+        { role: "user", content: _userMessage },
+      ],
+    },
+    { signal }
+  );
 };

--- a/src/features/chat-page/chat-services/chat-api/open-ai-stream.ts
+++ b/src/features/chat-page/chat-services/chat-api/open-ai-stream.ts
@@ -18,9 +18,26 @@ export const OpenAIStream = (props: {
 
   const readableStream = new ReadableStream({
     async start(controller) {
+      let controllerClosed = false;
+
+      const closeController = () => {
+        if (controllerClosed) return;
+        controllerClosed = true;
+        try {
+          controller.close();
+        } catch {
+          // already closed by client disconnect
+        }
+      };
+
       const streamResponse = (event: string, value: string) => {
-        controller.enqueue(encoder.encode(`event: ${event} \n`));
-        controller.enqueue(encoder.encode(`data: ${value} \n\n`));
+        if (controllerClosed) return;
+        try {
+          controller.enqueue(encoder.encode(`event: ${event} \n`));
+          controller.enqueue(encoder.encode(`data: ${value} \n\n`));
+        } catch {
+          controllerClosed = true;
+        }
       };
 
       let lastMessage = "";
@@ -85,7 +102,7 @@ export const OpenAIStream = (props: {
             response: "Chat aborted",
           };
           streamResponse(response.type, JSON.stringify(response));
-          controller.close();
+          closeController();
         })
         .on("error", async (error: any) => {
           console.log("🔴 error", error);
@@ -104,7 +121,7 @@ export const OpenAIStream = (props: {
           }
 
           streamResponse(response.type, JSON.stringify(response));
-          controller.close();
+          closeController();
         })
         .on("finalContent", async (content: string) => {
           await CreateChatMessage({
@@ -119,7 +136,7 @@ export const OpenAIStream = (props: {
             response: content,
           };
           streamResponse(response.type, JSON.stringify(response));
-          controller.close();
+          closeController();
         });
     },
   });

--- a/src/features/chat-page/chat-services/citation-service.ts
+++ b/src/features/chat-page/chat-services/citation-service.ts
@@ -96,20 +96,56 @@ export const FindCitationByID = async (
   }
 };
 
+function isBlobUrl(value?: string | null): boolean {
+  if (!value) return false;
+  try {
+    return new URL(value).hostname.endsWith(".blob.core.windows.net");
+  } catch {
+    return value.includes(".blob.core.windows.net");
+  }
+}
+
+function resolveCitationUrl(d: DocumentSearchResponse): string {
+  const fileUrl = d.document.fileUrl ?? "";
+  const effectiveFileUrl = d.document.effectiveFileUrl ?? "";
+
+  if (d.document.isSlDoc && isBlobUrl(effectiveFileUrl) && fileUrl) {
+    return fileUrl;
+  }
+
+  return effectiveFileUrl || fileUrl;
+}
+
 export const FormatCitations = (citation: DocumentSearchResponse[]) => {
   const withoutEmbedding: DocumentSearchResponse[] = [];
+
   citation.forEach((d) => {
+    const citationUrl = resolveCitationUrl(d);
+
+    console.log(
+      "[CITATION] effectiveFileUrl=",
+      d.document.effectiveFileUrl,
+      "fileUrl=",
+      d.document.fileUrl,
+      "citationUrl=",
+      citationUrl
+    );
+
     withoutEmbedding.push({
       score: d.score,
       document: {
         metadata: d.document.metadata,
         pageContent: d.document.pageContent,
         chatThreadId: d.document.chatThreadId,
-        fileUrl: d.document.fileUrl,
+
+        // ★★★ ここが修正ポイント ★★★
+        fileUrl: citationUrl,
+
+        effectiveFileUrl: citationUrl || null,
         id: "",
         user: "",
-        dept: d.document.dept ?? "",        // ★ 追加
-        isSlDoc: d.document.isSlDoc ?? false, // ★ 追加
+        dept: d.document.dept ?? "",
+        isSlDoc: d.document.isSlDoc ?? null,
       },
     });
   });

--- a/src/features/chat-page/citation/citation-file-download.tsx
+++ b/src/features/chat-page/citation/citation-file-download.tsx
@@ -2,16 +2,15 @@
 
 import { FindCitationByID } from "../chat-services/citation-service";
 import { GenerateSasUrl } from "@/features/common/services/azure-storage";
-export const CitationFileDownload = async (
-  formData: FormData
-) => {
-  const searchResponse = await FindCitationByID(formData.get("id") as string);
 
+export const CitationFileDownload = async (formData: FormData) => {
+  console.log("[DL] CitationFileDownload called, id=", formData.get("id"));
+  const searchResponse = await FindCitationByID(formData.get("id") as string);
   if (searchResponse.status === "OK") {
     const response = searchResponse.response;
-    const {document} = response.content;
-    return document.fileUrl
+    const { document } = response.content;
+    console.log("[DL] effectiveFileUrl=", document.effectiveFileUrl, "fileUrl=", document.fileUrl);
+    return document.effectiveFileUrl || document.fileUrl;
   }
-
   return null;
 };

--- a/src/features/common/services/azure-storage.ts
+++ b/src/features/common/services/azure-storage.ts
@@ -61,8 +61,9 @@ export const GenerateSasUrl = async (
   const blockBlobClient = containerClient.getBlockBlobClient(blobPath);
   const sasToken = generateBlobSASQueryParameters({
     containerName: containerName,
-    expiresOn: new Date(new Date().valueOf() + 86400),
-    permissions: BlobSASPermissions.parse("racwd")
+    blobName: blobPath,
+    expiresOn: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    permissions: BlobSASPermissions.parse("r")
   }, sharedKeyCredential);
   const sasUrl = `${blockBlobClient.url}?${sasToken}`;
   return {

--- a/src/features/main-menu/user-profile.tsx
+++ b/src/features/main-menu/user-profile.tsx
@@ -14,53 +14,83 @@ import { signOut, useSession } from "next-auth/react";
 import { Avatar, AvatarImage } from "../ui/avatar";
 import { ThemeToggle } from "./theme-toggle";
 
+const NON_SP_DEPTS = (process.env.NEXT_PUBLIC_SL_DEPT_NON_SP ?? "others")
+  .split(",")
+  .map((s) => s.trim().toLowerCase())
+  .filter(Boolean);
+
+function getRoleLabel(
+  slRole?: "global_admin" | "dept_admin" | "dept_member" | null,
+  slDept?: string | null
+): string {
+  if (slRole === "global_admin") return "全社管理者";
+
+  const deptLower = (slDept ?? "").trim().toLowerCase();
+  if (NON_SP_DEPTS.includes(deptLower)) return "";
+
+  const dept = deptLower.toUpperCase();
+  if (slRole === "dept_admin") return `${dept}管理者`;
+  if (slRole === "dept_member") return `${dept}員`;
+  return "";
+}
+
 export const UserProfile = () => {
   const { data: session } = useSession();
+  const roleLabel = getRoleLabel(session?.user?.slRole, session?.user?.slDept);
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        {session?.user?.image ? (
-          <Avatar className="">
-            <AvatarImage
-              src={session?.user?.image!}
-              alt={session?.user?.name!}
-            />
-          </Avatar>
-        ) : (
-          <CircleUserRound {...menuIconProps} role="button" />
-        )}
-      </DropdownMenuTrigger>
-      <DropdownMenuContent side="right" className="w-56" align="end">
-        <DropdownMenuLabel className="font-normal">
-          <div className="flex flex-col gap-2">
-            <p className="text-sm font-medium leading-none">
-              {session?.user?.name}
-            </p>
-            <p className="text-xs leading-none text-muted-foreground">
-              {session?.user?.email}
-            </p>
-            <p className="text-xs leading-none text-muted-foreground">
-              {session?.user?.isAdmin ? "Admin" : ""}
-            </p>
-          </div>
-        </DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        <DropdownMenuLabel className="font-normal">
-          <div className="flex flex-col gap-1">
-            <p className="text-sm font-medium leading-none">Switch themes</p>
-            <ThemeToggle />
-          </div>
-        </DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          className="flex gap-2"
-          onClick={() => signOut({ callbackUrl: "/" })}
-        >
-          <LogOut {...menuIconProps} size={18} />
-          <span>Log out</span>
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <div className="flex flex-col items-center gap-1 w-full">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          {session?.user?.image ? (
+            <Avatar className="">
+              <AvatarImage
+                src={session?.user?.image!}
+                alt={session?.user?.name!}
+              />
+            </Avatar>
+          ) : (
+            <CircleUserRound {...menuIconProps} role="button" />
+          )}
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="right" className="w-56" align="end">
+          <DropdownMenuLabel className="font-normal">
+            <div className="flex flex-col gap-2">
+              <p className="text-sm font-medium leading-none">
+                {session?.user?.name}
+              </p>
+              <p className="text-xs leading-none text-muted-foreground">
+                {session?.user?.email}
+              </p>
+              {roleLabel && (
+                <span className="inline-block self-start bg-primary text-primary-foreground text-xs font-medium px-2 py-0.5 rounded-full leading-tight">
+                  {roleLabel}
+                </span>
+              )}
+            </div>
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel className="font-normal">
+            <div className="flex flex-col gap-1">
+              <p className="text-sm font-medium leading-none">Switch themes</p>
+              <ThemeToggle />
+            </div>
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="flex gap-2"
+            onClick={() => signOut({ callbackUrl: "/" })}
+          >
+            <LogOut {...menuIconProps} size={18} />
+            <span>Log out</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {roleLabel && (
+        <span className="bg-primary text-primary-foreground text-[8px] font-medium leading-tight text-center rounded px-0.5 py-0.5 w-full block">
+          {roleLabel}
+        </span>
+      )}
+    </div>
   );
 };

--- a/src/lib/linkifyPhone.ts
+++ b/src/lib/linkifyPhone.ts
@@ -22,17 +22,37 @@ const ZENKAKU_MAP: Record<string, string> = {
   "　": " ",
 };
 
+/**
+ * 全角→半角の最低限変換
+ */
 function toHalfWidth(input: string): string {
   return input.replace(/[０-９＋－（）　]/g, (char) => ZENKAKU_MAP[char] ?? char);
 }
 
+/**
+ * tel: リンク用に電話番号を正規化
+ * - 全角数字を半角へ
+ * - 空白、ハイフン、括弧を除去
+ */
 export function normalizePhoneForTel(phone: string): string {
   return toHalfWidth(phone).replace(/[\s\-()]/g, "");
 }
 
+/**
+ * 日本の一般的な電話番号をざっくり検出
+ * 例:
+ * - 03-1234-5678
+ * - 090-1234-5678
+ * - +81-90-1234-5678
+ * - ０５３-１２３-４５６７
+ */
 const PHONE_REGEX =
   /(?:\+81[-\s]?\d{1,4}[-\s]?\d{1,4}[-\s]?\d{3,4}|0\d{1,4}[-\s]?\d{1,4}[-\s]?\d{3,4}|[０-９＋－（）\s]{10,20})/g;
 
+/**
+ * 電話番号として妥当かを軽く判定
+ * - 数字数が少なすぎるものを除外
+ */
 function looksLikePhone(raw: string): boolean {
   const normalized = normalizePhoneForTel(raw);
   const digitsOnly = normalized.replace(/[^\d+]/g, "");
@@ -40,6 +60,9 @@ function looksLikePhone(raw: string): boolean {
   return digitCount >= 10 && digitCount <= 15;
 }
 
+/**
+ * プレーンテキストを「通常文字列」と「電話番号」に分解
+ */
 export function splitTextWithPhones(text: string): TextPart[] {
   if (!text) {
     return [{ type: "text", value: "" }];
@@ -48,10 +71,9 @@ export function splitTextWithPhones(text: string): TextPart[] {
   const parts: TextPart[] = [];
   let lastIndex = 0;
 
-  // ★ matchAll → exec ループに変更（downlevelIteration不要）
-  let match: RegExpExecArray | null;
-  PHONE_REGEX.lastIndex = 0;
-  while ((match = PHONE_REGEX.exec(text)) !== null) {
+  const matches = Array.from(text.matchAll(PHONE_REGEX));  // ← 修正
+
+  for (const match of matches) {
     const raw = match[0];
     const index = match.index ?? 0;
 

--- a/src/lib/sl-dept.ts
+++ b/src/lib/sl-dept.ts
@@ -1,12 +1,15 @@
 // src/lib/sl-dept.ts
-// SharePoint連携(SL)の「メール → 部署判定」＋「部署設定取得」ユーティリティ
 
 export type SlDeptConfig = {
-  dept: string; // lower-case ("cp" | "ss" | "others" ...)
+  dept: string;
   siteUrl: string;
   driveName: string;
   folder: string;
 };
+
+export type UploadScope = "common" | "personal";
+
+const RESERVED_UPLOAD_SCOPES = new Set(["common", "personal"]);
 
 function parseCsv(value?: string): string[] {
   if (!value) return [];
@@ -16,14 +19,22 @@ function parseCsv(value?: string): string[] {
     .filter(Boolean);
 }
 
+function parseCsvLower(value?: string): string[] {
+  return parseCsv(value).map((s) => s.toLowerCase());
+}
+
 function parseCsvEmails(value?: string): Set<string> {
   return new Set(parseCsv(value).map((s) => s.toLowerCase()));
 }
 
+function normalizeOptionalEmail(email: string | null | undefined): string | null {
+  const normalized = (email ?? "").trim().toLowerCase();
+  return normalized || null;
+}
+
 export function getAllowedDepts(): string[] {
-  // 例: SL_DEPTS=cp,ss,others,common
   const raw = process.env.SL_DEPTS ?? "cp";
-  return parseCsv(raw).map((s) => s.toLowerCase());
+  return parseCsvLower(raw).filter((d) => !RESERVED_UPLOAD_SCOPES.has(d));
 }
 
 export function isAllowedDept(dept: string): boolean {
@@ -32,43 +43,121 @@ export function isAllowedDept(dept: string): boolean {
 }
 
 export function detectDeptByEmail(email: string): string | null {
-  const emailLc = email.trim().toLowerCase();
-  const allowed = getAllowedDepts();
+  return detectAllDeptsByEmail(email)[0] ?? null;
+}
 
-  for (const dept of allowed) {
+export function detectAllDeptsByEmail(email: string): string[] {
+  const emailLc = email.trim().toLowerCase();
+
+  return getAllowedDepts().filter((dept) => {
     const key = `SL_DEPT_BY_EMAIL_${dept.toUpperCase()}`;
     const set = parseCsvEmails(process.env[key]);
-    if (set.has(emailLc)) return dept;
+    return set.has(emailLc);
+  });
+}
+
+function getSafeDefaultDept(): string {
+  const allowed = getAllowedDepts();
+  const defaultDept = (process.env.SL_DEPT_DEFAULT ?? "cp").toLowerCase();
+
+  if (allowed.includes(defaultDept)) {
+    return defaultDept;
   }
-  return null;
+
+  if (allowed.length > 0) {
+    console.warn(
+      `[SL] SL_DEPT_DEFAULT="${defaultDept}" is not in SL_DEPTS. Fallback to "${allowed[0]}".`
+    );
+    return allowed[0];
+  }
+
+  throw new Error(`No allowed departments found. Check SL_DEPTS.`);
+}
+
+/**
+ * メールが指定されているがどの SL_DEPT_BY_EMAIL_* にもマッチしない場合の
+ * フォールバック部署を返す。SL_DEPT_NON_SP で設定された非SP部署を優先し、
+ * 見つからなければ SL_DEPT_DEFAULT に落ちる。
+ */
+function getUnknownEmailFallbackDept(): string {
+  const nonSpDepts = getNonSharePointDepts();
+  const allowed = getAllowedDepts();
+  return nonSpDepts.find((d) => allowed.includes(d)) ?? getSafeDefaultDept();
 }
 
 export function decideDept(params: {
   requestedDept?: string;
   userEmail?: string | null;
 }): string {
-  const defaultDept = (process.env.SL_DEPT_DEFAULT ?? "cp").toLowerCase();
+  const defaultDept = getSafeDefaultDept();
 
-  // 1) email → dept（メール登録リストを最優先）
   if (params.userEmail) {
     const hit = detectDeptByEmail(params.userEmail);
     if (hit) return hit;
+    // メールはあるが SL_DEPT_BY_EMAIL_* にマッチなし → 非SP部署にフォールバック
+    return getUnknownEmailFallbackDept();
   }
 
-  // 2) requested dept（メール未登録時のみ使用）
   if (params.requestedDept) {
     const d = params.requestedDept.trim().toLowerCase();
-    if (isAllowedDept(d)) return d;
-    console.warn(`[SL] Requested dept not allowed: "${params.requestedDept}" -> fallback`);
+
+    if (RESERVED_UPLOAD_SCOPES.has(d)) {
+      console.warn(`[SL] requestedDept="${d}" is uploadScope, not dept. ignored.`);
+    } else if (isAllowedDept(d)) {
+      return d;
+    } else {
+      console.warn(`[SL] Requested dept not allowed: "${params.requestedDept}" -> fallback`);
+    }
   }
 
-  // 3) default
   return defaultDept;
+}
+
+export function getNonSharePointDepts(): string[] {
+  return parseCsvLower(process.env.SL_DEPT_NON_SP ?? "others");
+}
+
+export function isSharePointEnabledDept(dept: string): boolean {
+  const d = dept.trim().toLowerCase();
+
+  if (!isAllowedDept(d)) {
+    throw new Error(`Dept "${dept}" is not allowed (check SL_DEPTS).`);
+  }
+
+  return !getNonSharePointDepts().includes(d);
+}
+
+export function normalizeUploadScope(value?: string | null): UploadScope {
+  const v = (value ?? "").trim().toLowerCase();
+
+  if (v === "common") return "common";
+  if (v === "personal") return "personal";
+  if (v === "cp") return "personal";
+
+  return "personal";
+}
+
+export function getPersonalFolderNameFromEmail(email: string): string {
+  const emailLc = email.trim().toLowerCase();
+  const at = emailLc.indexOf("@");
+  const localPart = at >= 0 ? emailLc.slice(0, at) : emailLc;
+
+  const sanitized = localPart
+    .replace(/[<>:"/\\|?*\x00-\x1f]/g, "_")
+    .replace(/\.+$/g, "")
+    .trim();
+
+  if (!sanitized) {
+    throw new Error(`Failed to build personal folder name from email: "${email}"`);
+  }
+
+  return sanitized;
 }
 
 export function getDeptConfig(deptLower: string): SlDeptConfig {
   const dept = deptLower.trim().toLowerCase();
-  if (!isAllowedDept(dept)) {
+
+  if (dept !== "common" && !isAllowedDept(dept)) {
     throw new Error(`Dept "${dept}" is not allowed (check SL_DEPTS).`);
   }
 
@@ -86,9 +175,26 @@ export function getDeptConfig(deptLower: string): SlDeptConfig {
   return { dept, siteUrl, driveName, folder };
 }
 
-/**
- * next-auth/jwt token から user email を取り出す（環境によりキーが揺れる）
- */
+export function buildUploadFolder(params: {
+  baseFolder: string;
+  uploadScope: UploadScope;
+  userEmail: string;
+}): string {
+  const baseFolder = params.baseFolder.trim().replace(/^\/+|\/+$/g, "");
+  if (!baseFolder) {
+    throw new Error("baseFolder is empty.");
+  }
+
+  if (params.uploadScope === "common") {
+    const commonSubfolder =
+      (process.env.SL_COMMON_SUBFOLDER ?? "common").trim() || "common";
+    return `${baseFolder}/${commonSubfolder}`;
+  }
+
+  const personalFolder = getPersonalFolderNameFromEmail(params.userEmail);
+  return `${baseFolder}/${personalFolder}`;
+}
+
 export function getUserEmailFromJwtToken(token: any): string | null {
   const candidates = [
     token?.email,
@@ -96,8 +202,177 @@ export function getUserEmailFromJwtToken(token: any): string | null {
     token?.upn,
     token?.unique_name,
   ];
+
   for (const c of candidates) {
-    if (typeof c === "string" && c.trim()) return c.trim();
+    if (typeof c === "string" && c.trim()) {
+      return c.trim().toLowerCase();
+    }
   }
+
   return null;
+}
+
+export function getEffectiveSlUserEmail(
+  email: string | null | undefined
+): string | null {
+  const localOverride = normalizeOptionalEmail(process.env.SL_LOCAL_DEFAULT_EMAIL);
+  const actualEmail = normalizeOptionalEmail(email);
+
+  if (process.env.NODE_ENV === "development" && localOverride) {
+    if (actualEmail) {
+      const globalAdminSet = parseCsvEmails(process.env.SL_ADMIN_EMAILS);
+      if (globalAdminSet.has(actualEmail)) {
+        return actualEmail;
+      }
+
+      if (getDeptAdminDepts(actualEmail).length > 0) {
+        return actualEmail;
+      }
+
+      if (detectAllDeptsByEmail(actualEmail).length > 0) {
+        return actualEmail;
+      }
+    }
+
+    return localOverride;
+  }
+
+  return actualEmail;
+}
+
+export type SlRole = "global_admin" | "dept_admin" | "dept_member";
+
+export type SlAccess = {
+  role: SlRole;
+  dept: string;
+};
+
+export type SlUploadTarget = {
+  dept: string;
+  access: SlAccess;
+};
+
+export function isDeptAdmin(email: string, dept: string): boolean {
+  const emailLc = email.trim().toLowerCase();
+  const key = `SL_DEPT_ADMIN_EMAILS_${dept.toUpperCase()}`;
+  const set = parseCsvEmails(process.env[key]);
+  return set.has(emailLc);
+}
+
+export function getDeptAdminDepts(email: string): string[] {
+  const emailLc = email.trim().toLowerCase();
+  return getAllowedDepts().filter((dept) => isDeptAdmin(emailLc, dept));
+}
+
+function pickPreferredDept(
+  preferredDept: string | null | undefined,
+  candidates: string[]
+): string {
+  const preferred = (preferredDept ?? "").trim().toLowerCase();
+  if (preferred && candidates.includes(preferred)) {
+    return preferred;
+  }
+
+  return candidates[0];
+}
+
+export function resolveSlAccess(
+  email: string | null | undefined,
+  preferredDept?: string | null
+): SlAccess {
+  const fallbackDept =
+    preferredDept && isAllowedDept(preferredDept)
+      ? preferredDept.trim().toLowerCase()
+      : getSafeDefaultDept();
+
+  if (!email) {
+    return { role: "dept_member", dept: fallbackDept };
+  }
+
+  const emailLc = email.trim().toLowerCase();
+
+  const globalAdminSet = parseCsvEmails(process.env.SL_ADMIN_EMAILS);
+  if (globalAdminSet.has(emailLc)) {
+    return {
+      role: "global_admin",
+      dept: decideDept({
+        requestedDept: preferredDept ?? undefined,
+        userEmail: emailLc,
+      }),
+    };
+  }
+
+  const adminDepts = getDeptAdminDepts(emailLc);
+  if (adminDepts.length > 0) {
+    return {
+      role: "dept_admin",
+      dept: pickPreferredDept(preferredDept, adminDepts),
+    };
+  }
+
+  const memberDepts = detectAllDeptsByEmail(emailLc);
+  if (memberDepts.length > 0) {
+    return {
+      role: "dept_member",
+      dept: pickPreferredDept(preferredDept, memberDepts),
+    };
+  }
+
+  // メール指定あるがどの SL_DEPT_BY_EMAIL_* にもマッチしないユーザー → 非SP部署
+  return {
+    role: "dept_member",
+    dept: getUnknownEmailFallbackDept(),
+  };
+}
+
+export function resolveSlRole(
+  email: string | null | undefined,
+  dept: string
+): SlRole {
+  return resolveSlAccess(email, dept).role;
+}
+
+export function resolveSlUploadTarget(
+  email: string | null | undefined,
+  uploadScope: UploadScope,
+  preferredDept?: string | null
+): SlUploadTarget {
+  const access = resolveSlAccess(email, preferredDept);
+  const emailDept = email ? detectDeptByEmail(email) : null;
+
+  if (uploadScope === "common") {
+    if (access.role === "global_admin") {
+      return {
+        dept: "common",
+        access,
+      };
+    }
+
+    return {
+      dept: access.dept,
+      access,
+    };
+  }
+
+  if (emailDept) {
+    return {
+      dept: emailDept,
+      access,
+    };
+  }
+
+  if (access.role === "dept_admin") {
+    return {
+      dept: access.dept,
+      access,
+    };
+  }
+
+  return {
+    dept: decideDept({
+      requestedDept: preferredDept ?? undefined,
+      userEmail: email ?? undefined,
+    }),
+    access,
+  };
 }

--- a/src/lib/sl-sync.ts
+++ b/src/lib/sl-sync.ts
@@ -1,0 +1,945 @@
+// src/lib/sl-sync.ts
+
+import { getAllowedDepts, getDeptConfig } from "@/lib/sl-dept";
+
+export type SpFileItem = {
+  id: string;
+  name: string;
+  webUrl: string;
+  sourceSiteUrl: string;
+  relativePath: string;
+};
+
+export type SlSyncDeptResult = {
+  spFileNames: number;
+  indexDocs: number | "unknown";
+  orphanIds?: string[];
+  deleted: number;
+  urlUpdated?: number;
+  skipped?: string;
+  error?: string;
+};
+
+export type SlSyncResult = {
+  ok: true;
+  mode: "dry-run" | "apply";
+  results: Record<string, SlSyncDeptResult>;
+};
+
+export type RunSlSyncParams = {
+  accessToken: string;
+  apply?: boolean;
+};
+
+type IndexDoc = {
+  id: string;
+  fileName: string;
+  fileUrl: string;
+  effectiveFileUrl: string;
+  slScope: string | null;
+  relativePath: string | null;
+  spItemId: string | null;
+};
+
+type ScopeKind = "global_common" | "dept_common" | "personal";
+
+type GlobalCommonConfig = {
+  siteUrl: string;
+  driveName: string;
+  folder: string;
+};
+
+type SpInventory = {
+  allItems: SpFileItem[];
+  byName: Map<string, SpFileItem[]>;
+  byId: Map<string, SpFileItem>;
+};
+
+function encodeGraphPath(path: string): string {
+  return (path ?? "")
+    .split("/")
+    .filter(Boolean)
+    .map((seg) => encodeURIComponent(seg))
+    .join("/");
+}
+
+function safeDecodeURIComponent(v: string): string {
+  try {
+    return decodeURIComponent(v);
+  } catch {
+    return v;
+  }
+}
+
+function normalizeSiteUrl(siteUrl: string): string {
+  return (siteUrl ?? "").replace(/\/+$/, "").toLowerCase();
+}
+
+function normalizeFolderPath(path: string): string {
+  return (path ?? "")
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "");
+}
+
+function pathStartsWith(path: string, prefix: string): boolean {
+  const p = normalizeFolderPath(path).toLowerCase();
+  const f = normalizeFolderPath(prefix).toLowerCase();
+  return p === f || p.startsWith(`${f}/`);
+}
+
+function getDecodedPathnameFromWebUrl(webUrl: string): string {
+  try {
+    const u = new URL(webUrl);
+    return safeDecodeURIComponent(u.pathname);
+  } catch {
+    return safeDecodeURIComponent(webUrl);
+  }
+}
+
+function getGlobalCommonConfig(): GlobalCommonConfig | null {
+  const siteUrl = process.env.SL_COMMON_SITE_URL;
+  const driveName = process.env.SL_COMMON_DRIVE_NAME;
+  const folder = process.env.SL_COMMON_FOLDER || "Common";
+
+  if (!siteUrl || !driveName) return null;
+  return { siteUrl, driveName, folder };
+}
+
+function deriveDeptCommonFolder(baseFolder: string): string {
+  return `${normalizeFolderPath(baseFolder)}/Common`;
+}
+
+function isWithinFolderByWebUrl(webUrl: string, folderPath: string): boolean {
+  const decodedPathname = getDecodedPathnameFromWebUrl(webUrl).toLowerCase();
+  const normalizedFolder = normalizeFolderPath(folderPath).toLowerCase();
+
+  return (
+    decodedPathname.includes(`/${normalizedFolder}/`) ||
+    decodedPathname.endsWith(`/${normalizedFolder}`)
+  );
+}
+
+function resolveScopeFromLocation(params: {
+  webUrl: string;
+  sourceSiteUrl: string;
+  deptSiteUrl: string;
+  deptBaseFolder: string;
+  globalCommonSiteUrl?: string | null;
+  globalCommonFolder?: string | null;
+}): ScopeKind {
+  const {
+    webUrl,
+    sourceSiteUrl,
+    deptSiteUrl,
+    deptBaseFolder,
+    globalCommonSiteUrl,
+    globalCommonFolder,
+  } = params;
+
+  const sourceSite = normalizeSiteUrl(sourceSiteUrl);
+  const deptSite = normalizeSiteUrl(deptSiteUrl);
+  const globalSite = normalizeSiteUrl(globalCommonSiteUrl || "");
+  const deptCommonFolder = deriveDeptCommonFolder(deptBaseFolder);
+
+  if (
+    globalSite &&
+    sourceSite === globalSite &&
+    globalCommonFolder &&
+    isWithinFolderByWebUrl(webUrl, globalCommonFolder)
+  ) {
+    return "global_common";
+  }
+
+  if (sourceSite === deptSite && isWithinFolderByWebUrl(webUrl, deptCommonFolder)) {
+    return "dept_common";
+  }
+
+  return "personal";
+}
+
+function buildInventory(items: SpFileItem[]): SpInventory {
+  const byName = new Map<string, SpFileItem[]>();
+  const byId = new Map<string, SpFileItem>();
+
+  for (const item of items) {
+    const key = item.name.toLowerCase();
+    const bucket = byName.get(key) ?? [];
+    bucket.push(item);
+    byName.set(key, bucket);
+
+    if (item.id) {
+      byId.set(item.id, item);
+    }
+  }
+
+  return { allItems: items, byName, byId };
+}
+
+function extractRelativePathFromWebUrl(
+  webUrl: string,
+  roots: Array<{ siteUrl: string; folder: string }>
+): string | null {
+  const decodedPathname = getDecodedPathnameFromWebUrl(webUrl).toLowerCase();
+
+  for (const root of roots) {
+    const sitePath = (() => {
+      try {
+        return safeDecodeURIComponent(new URL(root.siteUrl).pathname).toLowerCase();
+      } catch {
+        return "";
+      }
+    })();
+
+    if (!sitePath || !decodedPathname.startsWith(sitePath)) {
+      continue;
+    }
+
+    const rootFolder = normalizeFolderPath(root.folder).toLowerCase();
+    const marker = `/${rootFolder}/`;
+    const markerIndex = decodedPathname.indexOf(marker);
+
+    if (markerIndex >= 0) {
+      return decodedPathname.slice(markerIndex + 1);
+    }
+
+    const endMarker = `/${rootFolder}`;
+    if (decodedPathname.endsWith(endMarker)) {
+      return rootFolder;
+    }
+  }
+
+  return null;
+}
+
+function resolveIndexRelativePath(
+  doc: Pick<IndexDoc, "effectiveFileUrl" | "fileUrl">,
+  deptSiteUrl: string,
+  deptBaseFolder: string,
+  globalCommon?: GlobalCommonConfig | null
+): string | null {
+  const roots = [{ siteUrl: deptSiteUrl, folder: deptBaseFolder }];
+  if (globalCommon) {
+    roots.push({
+      siteUrl: globalCommon.siteUrl,
+      folder: globalCommon.folder,
+    });
+  }
+
+  return (
+    extractRelativePathFromWebUrl(doc.effectiveFileUrl, roots) ??
+    extractRelativePathFromWebUrl(doc.fileUrl, roots)
+  );
+}
+
+/**
+ * spItemId を使って Graph API でドライブ内のアイテムを直接ルックアップ。
+ * scan 範囲外（基点フォルダより上位）に移動されたファイルを追跡するために使用。
+ */
+async function lookupSpItemByIdInDrive(
+  accessToken: string,
+  siteUrl: string,
+  driveName: string,
+  itemId: string
+): Promise<SpFileItem | null> {
+  try {
+    const siteId = await resolveSiteId(accessToken, siteUrl);
+    const driveId = await resolveDriveId(accessToken, siteId, driveName);
+
+    const res = await fetch(
+      `https://graph.microsoft.com/v1.0/drives/${driveId}/items/${itemId}` +
+        `?$select=name,file,id,webUrl,parentReference,deleted`,
+      { headers: { Authorization: `Bearer ${accessToken}` }, cache: "no-store" }
+    );
+
+    if (res.status === 404) return null; // ファイルが実際に削除済み（ゴミ箱も空）
+    if (!res.ok) {
+      console.warn(`[SL sync] lookupSpItemById failed (${res.status}): ${await res.text()}`);
+      return null;
+    }
+
+    const item = await res.json();
+
+    // ★ ゴミ箱に入ったアイテムは deleted ファセットが付く → 削除済みとして扱いorphan化
+    if (item?.deleted) {
+      console.log(`[SL sync] lookupSpItemByIdInDrive: item in Recycle Bin, treating as deleted: itemId=${itemId}`);
+      return null;
+    }
+
+    if (!item?.file || !item?.name) return null; // フォルダ等はスキップ
+
+    // parentReference.path = "/drives/{id}/root:/folder/path" 形式
+    const parentPath = (() => {
+      const raw: string = item.parentReference?.path ?? "";
+      const rootIdx = raw.indexOf("root:");
+      if (rootIdx < 0) return "";
+      return normalizeFolderPath(safeDecodeURIComponent(raw.slice(rootIdx + 5)));
+    })();
+
+    const relativePath = parentPath
+      ? normalizeFolderPath(`${parentPath}/${item.name}`)
+      : normalizeFolderPath(String(item.name));
+
+    return {
+      id: String(item.id),
+      name: String(item.name),
+      webUrl: String(item.webUrl),
+      sourceSiteUrl: siteUrl,
+      relativePath,
+    };
+  } catch (e) {
+    console.warn(`[SL sync] lookupSpItemByIdInDrive error:`, e);
+    return null;
+  }
+}
+
+function findMatchingSpItem(doc: IndexDoc, inventory: SpInventory): SpFileItem | null {
+  // 第1優先: SP item ID（ファイル移動後も不変）
+  if (doc.spItemId) {
+    const byId = inventory.byId.get(doc.spItemId);
+    if (byId) return byId;
+  }
+
+  // 第2優先: relativePath の完全一致（spItemId 未保存の旧ドキュメント向け）
+  if (doc.relativePath) {
+    const exact = inventory.allItems.find(
+      (item) => item.relativePath.toLowerCase() === doc.relativePath?.toLowerCase()
+    );
+    if (exact) return exact;
+  }
+
+  // 第3優先: ファイル名一致（同名が1件のみの場合）
+  const sameName = inventory.byName.get(doc.fileName.toLowerCase()) ?? [];
+  if (sameName.length === 1) {
+    return sameName[0];
+  }
+
+  return null;
+}
+
+async function resolveSiteId(accessToken: string, siteUrl: string): Promise<string> {
+  const url = new URL(siteUrl);
+  const res = await fetch(
+    `https://graph.microsoft.com/v1.0/sites/${url.hostname}:${url.pathname}`,
+    { headers: { Authorization: `Bearer ${accessToken}` }, cache: "no-store" }
+  );
+  if (!res.ok) throw new Error(`Failed to get site: ${await res.text()}`);
+  const json = await res.json();
+  return json.id as string;
+}
+
+async function resolveDriveId(
+  accessToken: string,
+  siteId: string,
+  driveName: string
+): Promise<string> {
+  const res = await fetch(`https://graph.microsoft.com/v1.0/sites/${siteId}/drives`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    cache: "no-store",
+  });
+  if (!res.ok) throw new Error(`Failed to get drives: ${await res.text()}`);
+  const json = await res.json();
+  const drive = (json.value ?? []).find((d: any) => d.name === driveName);
+  if (!drive) {
+    const names = (json.value ?? []).map((d: any) => d.name).join(", ");
+    throw new Error(`Drive "${driveName}" not found. Available: ${names}`);
+  }
+  return drive.id as string;
+}
+
+async function collectFileItemsRecursive(
+  accessToken: string,
+  driveId: string,
+  currentFolderPath: string,
+  sourceSiteUrl: string,
+  fileItems: SpFileItem[],
+  isRoot = false
+): Promise<{ fetchFailed: boolean; rootMissing: boolean }> {
+  const encoded = encodeGraphPath(currentFolderPath);
+  let nextUrl: string | null =
+    `https://graph.microsoft.com/v1.0/drives/${driveId}` +
+    `/root:/${encoded}:/children?$select=name,file,folder,id,webUrl,parentReference&$top=200`;
+
+  while (nextUrl) {
+    const res: Response = await fetch(nextUrl, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      cache: "no-store",
+    });
+
+    if (res.status === 404) {
+      console.warn(`[SL sync] Folder not found (404): ${currentFolderPath}`);
+      // isRoot=true ならベースフォルダ自体が存在しない → rootMissing
+      return { fetchFailed: true, rootMissing: isRoot };
+    }
+
+    if (!res.ok) {
+      throw new Error(`Failed to list folder "${currentFolderPath}": ${await res.text()}`);
+    }
+
+    const json: any = await res.json();
+
+    for (const item of json.value ?? []) {
+      if (item?.file && item?.name) {
+        fileItems.push({
+          id: String(item.id ?? ""),
+          name: String(item.name ?? ""),
+          webUrl: String(item.webUrl ?? ""),
+          sourceSiteUrl,
+          relativePath: normalizeFolderPath(`${currentFolderPath}/${item.name}`),
+        });
+      } else if (item?.folder && item?.name) {
+        const child = await collectFileItemsRecursive(
+          accessToken,
+          driveId,
+          `${currentFolderPath}/${item.name}`,
+          sourceSiteUrl,
+          fileItems,
+          false  // 子フォルダは isRoot=false
+        );
+        if (child.fetchFailed) {
+          console.warn(`[SL sync] Child folder fetch failed: ${currentFolderPath}/${item.name}`);
+          return { fetchFailed: true, rootMissing: false };
+        }
+      }
+    }
+
+    nextUrl = json["@odata.nextLink"] ?? null;
+  }
+
+  return { fetchFailed: false, rootMissing: false };
+}
+
+async function getSpFileItemsForFolder(
+  accessToken: string,
+  siteUrl: string,
+  driveName: string,
+  folderPath: string
+): Promise<{ inventory: SpInventory; fetchFailed: boolean; rootMissing: boolean }> {
+  const siteId = await resolveSiteId(accessToken, siteUrl);
+  const driveId = await resolveDriveId(accessToken, siteId, driveName);
+
+  const fileItems: SpFileItem[] = [];
+  const { fetchFailed, rootMissing } = await collectFileItemsRecursive(
+    accessToken,
+    driveId,
+    folderPath,
+    siteUrl,
+    fileItems,
+    true  // ベースフォルダ呼び出しは isRoot=true
+  );
+
+  console.log(
+    `[SL sync] SP recursive scan: site="${siteUrl}" folder="${folderPath}" total=${fileItems.length} fetchFailed=${fetchFailed} rootMissing=${rootMissing}`
+  );
+
+  return { inventory: buildInventory(fileItems), fetchFailed, rootMissing };
+}
+
+async function getSpFileItems(
+  accessToken: string,
+  deptSiteUrl: string,
+  deptDriveName: string,
+  deptBaseFolder: string
+): Promise<{ inventory: SpInventory; fetchFailed: boolean; rootMissing: boolean }> {
+  const deptScan = await getSpFileItemsForFolder(
+    accessToken,
+    deptSiteUrl,
+    deptDriveName,
+    deptBaseFolder
+  );
+
+  if (deptScan.fetchFailed) {
+    // rootMissing を上位に伝播させる（ベースフォルダ不在の情報を保持）
+    return { inventory: buildInventory([]), fetchFailed: true, rootMissing: deptScan.rootMissing };
+  }
+
+  const merged = [...deptScan.inventory.allItems];
+  const globalCommon = getGlobalCommonConfig();
+
+  if (globalCommon) {
+    const globalScan = await getSpFileItemsForFolder(
+      accessToken,
+      globalCommon.siteUrl,
+      globalCommon.driveName,
+      globalCommon.folder
+    );
+
+    if (!globalScan.fetchFailed) {
+      merged.push(...globalScan.inventory.allItems);
+    } else {
+      console.warn(
+        `[SL sync] Global common scan skipped: ${globalCommon.siteUrl} / ${globalCommon.folder}`
+      );
+    }
+  }
+
+  console.log(
+    `[SL sync] SP merged scan: deptBaseFolder="${deptBaseFolder}" total=${merged.length}`
+  );
+
+  return { inventory: buildInventory(merged), fetchFailed: false, rootMissing: false };
+}
+
+async function getIndexDocs(
+  dept: string,
+  deptSiteUrl: string,
+  deptBaseFolder: string,
+  globalCommon?: GlobalCommonConfig | null
+): Promise<IndexDoc[]> {
+  const endpoint = process.env.AZURE_SEARCH_ENDPOINT;
+  const indexName = process.env.AZURE_SEARCH_INDEX_NAME;
+  const apiKey = process.env.AZURE_SEARCH_API_KEY;
+
+  if (!endpoint || !apiKey || !indexName) {
+    throw new Error("Missing Azure Search env vars");
+  }
+
+  const docs: IndexDoc[] = [];
+  let skip = 0;
+  const top = 200;
+
+  while (true) {
+    const res = await fetch(
+      `${endpoint}/indexes/${indexName}/docs?api-version=2024-07-01` +
+        `&$select=id,metadata,fileUrl,effectiveFileUrl,dept,slScope,spItemId` +
+        `&$filter=(dept eq '${dept.replace(/'/g, "''")}' or slScope eq 'global_common') and isSlDoc eq true` +
+        `&$top=${top}&$skip=${skip}`,
+      {
+        headers: { "api-key": apiKey, "Content-Type": "application/json" },
+        cache: "no-store",
+      }
+    );
+
+    if (!res.ok) throw new Error(`Search query failed: ${await res.text()}`);
+
+    const json = await res.json();
+    const items: any[] = json.value ?? [];
+    if (items.length === 0) break;
+
+    for (const item of items) {
+      const fileUrl = String(item.fileUrl ?? "");
+      const effectiveFileUrl = String(item.effectiveFileUrl ?? "");
+      // metadata が最も信頼できるファイル名。URLパースをフォールバックとする
+      const fileName =
+        String(item.metadata ?? "").trim() ||
+        safeDecodeURIComponent(effectiveFileUrl).split("/").pop() ||
+        safeDecodeURIComponent(fileUrl).split("/").pop() ||
+        "";
+
+      if (item.id && fileName) {
+        const doc: IndexDoc = {
+          id: String(item.id),
+          fileName,
+          fileUrl,
+          effectiveFileUrl,
+          slScope: item.slScope == null ? null : String(item.slScope),
+          relativePath: null,
+          spItemId: item.spItemId ? String(item.spItemId) : null,
+        };
+        doc.relativePath = resolveIndexRelativePath(
+          doc,
+          deptSiteUrl,
+          deptBaseFolder,
+          globalCommon
+        );
+        docs.push(doc);
+      }
+    }
+
+    skip += items.length;
+    if (items.length < top) break;
+  }
+
+  return docs;
+}
+
+async function getIndexDocsGlobalCommon(
+  globalCommon: GlobalCommonConfig
+): Promise<IndexDoc[]> {
+  const endpoint = process.env.AZURE_SEARCH_ENDPOINT;
+  const indexName = process.env.AZURE_SEARCH_INDEX_NAME;
+  const apiKey = process.env.AZURE_SEARCH_API_KEY;
+
+  if (!endpoint || !apiKey || !indexName) {
+    throw new Error("Missing Azure Search env vars");
+  }
+
+  const docs: IndexDoc[] = [];
+  let skip = 0;
+  const top = 200;
+
+  while (true) {
+    const res = await fetch(
+      `${endpoint}/indexes/${indexName}/docs?api-version=2024-07-01` +
+        `&$select=id,metadata,fileUrl,effectiveFileUrl,dept,slScope,spItemId` +
+        `&$filter=slScope eq 'global_common' and isSlDoc eq true` +
+        `&$top=${top}&$skip=${skip}`,
+      {
+        headers: { "api-key": apiKey, "Content-Type": "application/json" },
+        cache: "no-store",
+      }
+    );
+
+    if (!res.ok) throw new Error(`Search query failed: ${await res.text()}`);
+
+    const json = await res.json();
+    const items: any[] = json.value ?? [];
+    if (items.length === 0) break;
+
+    for (const item of items) {
+      const fileUrl = String(item.fileUrl ?? "");
+      const effectiveFileUrl = String(item.effectiveFileUrl ?? "");
+      const fileName =
+        String(item.metadata ?? "").trim() ||
+        safeDecodeURIComponent(effectiveFileUrl).split("/").pop() ||
+        safeDecodeURIComponent(fileUrl).split("/").pop() ||
+        "";
+
+      if (item.id && fileName) {
+        const doc: IndexDoc = {
+          id: String(item.id),
+          fileName,
+          fileUrl,
+          effectiveFileUrl,
+          slScope: item.slScope == null ? null : String(item.slScope),
+          relativePath: null,
+          spItemId: item.spItemId ? String(item.spItemId) : null,
+        };
+        doc.relativePath = resolveIndexRelativePath(
+          doc,
+          globalCommon.siteUrl,
+          globalCommon.folder,
+          null
+        );
+        docs.push(doc);
+      }
+    }
+
+    skip += items.length;
+    if (items.length < top) break;
+  }
+
+  return docs;
+}
+
+async function deleteIndexDocs(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+
+  const endpoint = process.env.AZURE_SEARCH_ENDPOINT;
+  const apiKey = process.env.AZURE_SEARCH_API_KEY;
+  const indexName = process.env.AZURE_SEARCH_INDEX_NAME;
+
+  if (!endpoint || !apiKey || !indexName) {
+    throw new Error("Missing Azure Search env vars");
+  }
+
+  const body = {
+    value: ids.map((id) => ({ "@search.action": "delete", id })),
+  };
+
+  const res = await fetch(
+    `${endpoint}/indexes/${indexName}/docs/index?api-version=2024-07-01`,
+    {
+      method: "POST",
+      headers: { "api-key": apiKey, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      cache: "no-store",
+    }
+  );
+
+  if (!res.ok) throw new Error(`Delete failed: ${await res.text()}`);
+  console.log(`[SL sync] Deleted ${ids.length} index docs`);
+}
+
+async function updateIndexDocs(
+  updates: Array<{
+    id: string;
+    effectiveFileUrl: string;
+    slScope?: ScopeKind;
+    slOwner?: string | null;
+  }>
+): Promise<void> {
+  if (updates.length === 0) return;
+
+  const endpoint = process.env.AZURE_SEARCH_ENDPOINT;
+  const apiKey = process.env.AZURE_SEARCH_API_KEY;
+  const indexName = process.env.AZURE_SEARCH_INDEX_NAME;
+
+  if (!endpoint || !apiKey || !indexName) {
+    throw new Error("Missing Azure Search env vars");
+  }
+
+  const body = {
+    value: updates.map(({ id, effectiveFileUrl, slScope, slOwner }) => {
+      const doc: any = {
+        "@search.action": "merge",
+        id,
+        effectiveFileUrl,
+      };
+      if (slScope !== undefined) doc.slScope = slScope;
+      if (slOwner !== undefined) doc.slOwner = slOwner;
+      return doc;
+    }),
+  };
+
+  const res = await fetch(
+    `${endpoint}/indexes/${indexName}/docs/index?api-version=2024-07-01`,
+    {
+      method: "POST",
+      headers: { "api-key": apiKey, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      cache: "no-store",
+    }
+  );
+
+  if (!res.ok) throw new Error(`Index update failed: ${await res.text()}`);
+  console.log(`[SL sync] Updated ${updates.length} docs`);
+}
+
+export async function runSlSync({
+  accessToken,
+  apply = false,
+}: RunSlSyncParams): Promise<SlSyncResult> {
+  const results: Record<string, SlSyncDeptResult> = {};
+
+  for (const dept of getAllowedDepts()) {
+    try {
+      const { siteUrl, driveName, folder: baseFolder } = getDeptConfig(dept);
+      const globalCommon = getGlobalCommonConfig();
+
+      const { inventory, fetchFailed, rootMissing } = await getSpFileItems(
+        accessToken,
+        siteUrl,
+        driveName,
+        baseFolder
+      );
+
+      console.log(
+        `[SL sync] dept=${dept} SP fileItems=${inventory.allItems.length} fetchFailed=${fetchFailed} rootMissing=${rootMissing}`
+      );
+
+      if (fetchFailed) {
+        if (rootMissing) {
+          // ベースフォルダ自体が存在しない → SP上にファイルは0件確定
+          // インデックス上の孤立ドキュメントをすべて削除する
+          const indexDocs = await getIndexDocs(dept, siteUrl, baseFolder, globalCommon);
+          const orphanIds = indexDocs
+            .filter((doc) => doc.slScope !== "global_common")
+            .map((doc) => doc.id);
+          console.log(
+            `[SL sync] dept=${dept} base folder missing, orphans=${orphanIds.length} apply=${apply}`
+          );
+          if (apply && orphanIds.length > 0) {
+            await deleteIndexDocs(orphanIds);
+          }
+          results[dept] = {
+            spFileNames: 0,
+            indexDocs: indexDocs.length,
+            deleted: apply ? orphanIds.length : 0,
+            orphanIds,
+          };
+        } else {
+          // 子フォルダの一時的な 404 → 安全のためスキップ
+          results[dept] = {
+            spFileNames: 0,
+            indexDocs: "unknown",
+            deleted: 0,
+            skipped: "sp_fetch_failed",
+          };
+        }
+        continue;
+      }
+
+      const indexDocs = await getIndexDocs(dept, siteUrl, baseFolder, globalCommon);
+      console.log(`[SL sync] dept=${dept} indexed docs=${indexDocs.length}`);
+
+      const matchedDocs = indexDocs.map((doc) => ({
+        doc,
+        spItem: findMatchingSpItem(doc, inventory),
+      }));
+
+      // scan 範囲外（基点フォルダより上位など）へ移動したファイルを Graph API で直接追跡
+      const scanMissed = matchedDocs.filter(
+        (entry) => !entry.spItem && entry.doc.spItemId && entry.doc.slScope !== "global_common"
+      );
+      if (scanMissed.length > 0) {
+        console.log(`[SL sync] dept=${dept} looking up ${scanMissed.length} scan-missed items by spItemId`);
+        for (const entry of scanMissed) {
+          const found = await lookupSpItemByIdInDrive(
+            accessToken,
+            siteUrl,
+            driveName,
+            entry.doc.spItemId!
+          );
+          if (found) {
+            entry.spItem = found;
+            console.log(`[SL sync] dept=${dept} found outside scan scope: ${entry.doc.fileName} → ${found.webUrl}`);
+          }
+        }
+      }
+
+      const orphanIds = matchedDocs
+        .filter(({ doc }) => doc.slScope !== "global_common")
+        .filter(({ doc }) => !doc.spItemId)
+        .filter(({ spItem }) => !spItem)
+        .map(({ doc }) => doc.id);
+
+      const gcExcluded = matchedDocs.filter(({ doc, spItem }) => doc.slScope === "global_common" && !spItem).length;
+      if (gcExcluded > 0) {
+        console.log(`[SL sync] dept=${dept} global_common docs outside scan (excluded from orphan): ${gcExcluded}`);
+      }
+      console.log(`[SL sync] dept=${dept} orphans=${orphanIds.length} apply=${apply}`);
+
+      // global_common ドキュメントは global_common ブロックが管理する。
+      // dept ループで slScope を上書きするとドキュメントが消失するため除外する。
+      const docUpdates = matchedDocs
+        .filter((entry): entry is { doc: IndexDoc; spItem: SpFileItem } => Boolean(entry.spItem))
+        .filter(({ doc }) => doc.slScope !== "global_common")
+        .filter(({ doc, spItem }) => {
+          const desiredScope = resolveScopeFromLocation({
+            webUrl: spItem.webUrl,
+            sourceSiteUrl: spItem.sourceSiteUrl,
+            deptSiteUrl: siteUrl,
+            deptBaseFolder: baseFolder,
+            globalCommonSiteUrl: globalCommon?.siteUrl ?? null,
+            globalCommonFolder: globalCommon?.folder ?? null,
+          });
+
+          return doc.effectiveFileUrl !== spItem.webUrl || doc.slScope !== desiredScope;
+        })
+        .map(({ doc, spItem }) => {
+          const desiredScope = resolveScopeFromLocation({
+            webUrl: spItem.webUrl,
+            sourceSiteUrl: spItem.sourceSiteUrl,
+            deptSiteUrl: siteUrl,
+            deptBaseFolder: baseFolder,
+            globalCommonSiteUrl: globalCommon?.siteUrl ?? null,
+            globalCommonFolder: globalCommon?.folder ?? null,
+          });
+
+          return {
+            id: doc.id,
+            effectiveFileUrl: spItem.webUrl,
+            slScope: desiredScope,
+            ...(desiredScope === "personal" ? {} : { slOwner: null }),
+          };
+        });
+
+      if (apply) {
+        await deleteIndexDocs(orphanIds);
+        await updateIndexDocs(docUpdates);
+      }
+
+      results[dept] = {
+        spFileNames: inventory.allItems.length,
+        indexDocs: indexDocs.length,
+        deleted: apply ? orphanIds.length : 0,
+        urlUpdated: docUpdates.length,
+        orphanIds,
+      };
+    } catch (deptErr: any) {
+      console.error(`[SL sync] dept=${dept} error:`, deptErr);
+      results[dept] = {
+        spFileNames: 0,
+        indexDocs: 0,
+        deleted: 0,
+        error: String(deptErr?.message ?? deptErr),
+      };
+    }
+  }
+
+  try {
+    const globalCommon = getGlobalCommonConfig();
+    if (globalCommon) {
+      const globalScan = await getSpFileItemsForFolder(
+        accessToken,
+        globalCommon.siteUrl,
+        globalCommon.driveName,
+        globalCommon.folder
+      );
+
+      if (!globalScan.fetchFailed) {
+        const globalIndexDocs = await getIndexDocsGlobalCommon(globalCommon);
+        console.log(`[SL sync] global_common SP files=${globalScan.inventory.allItems.length} indexed docs=${globalIndexDocs.length}`);
+        const matchedDocs = globalIndexDocs.map((doc) => ({
+          doc,
+          spItem: findMatchingSpItem(doc, globalScan.inventory),
+        }));
+
+        // scan 範囲外（Common フォルダ外）へ移動したファイルを Graph API で直接追跡
+        const globalScanMissed = matchedDocs.filter(
+          (entry) => !entry.spItem && entry.doc.spItemId
+        );
+        if (globalScanMissed.length > 0) {
+          console.log(`[SL sync] global_common looking up ${globalScanMissed.length} scan-missed items by spItemId`);
+          for (const entry of globalScanMissed) {
+            const found = await lookupSpItemByIdInDrive(
+              accessToken,
+              globalCommon.siteUrl,
+              globalCommon.driveName,
+              entry.doc.spItemId!
+            );
+            if (found) {
+              entry.spItem = found;
+              console.log(`[SL sync] global_common found outside scan scope: ${entry.doc.fileName} → ${found.webUrl}`);
+            }
+          }
+        }
+
+        const globalOrphanIds = matchedDocs
+          .filter(({ spItem }) => !spItem)
+          .map(({ doc }) => doc.id);
+
+        const docUpdates = matchedDocs
+          .filter(
+            (entry): entry is { doc: IndexDoc; spItem: SpFileItem } =>
+              Boolean(entry.spItem)
+          )
+          .filter(({ doc, spItem }) => doc.effectiveFileUrl !== spItem.webUrl)
+          .map(({ doc, spItem }) => ({
+            id: doc.id,
+            effectiveFileUrl: spItem.webUrl,
+          }));
+
+        if (globalOrphanIds.length > 0) {
+          console.log(
+            `[SL sync] global_common orphans=${globalOrphanIds.length}; keeping index docs because files may have been moved outside Common temporarily.`
+          );
+        }
+
+        if (apply) {
+          if (docUpdates.length > 0) await updateIndexDocs(docUpdates);
+        }
+
+        results["global_common"] = {
+          spFileNames: globalScan.inventory.allItems.length,
+          indexDocs: globalIndexDocs.length,
+          deleted: 0,
+          urlUpdated: docUpdates.length,
+          orphanIds: globalOrphanIds,
+        };
+      } else {
+        results["global_common"] = {
+          spFileNames: 0,
+          indexDocs: 0,
+          deleted: 0,
+          skipped: "sp_fetch_failed",
+        };
+      }
+    }
+  } catch (globalErr: any) {
+    console.error(`[SL sync] global_common error:`, globalErr);
+    results["global_common"] = {
+      spFileNames: 0,
+      indexDocs: 0,
+      deleted: 0,
+      error: String(globalErr?.message ?? globalErr),
+    };
+  }
+
+  return {
+    ok: true,
+    mode: apply ? "apply" : "dry-run",
+    results,
+  };
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -6,11 +6,15 @@ declare module "next-auth" {
   interface Session {
     user: {
       isAdmin: boolean;
+      slRole?: "global_admin" | "dept_admin" | "dept_member";
+      slDept?: string;
     } & DefaultSession["user"];
   }
 
   interface Token {
     isAdmin: boolean;
+    slRole?: "global_admin" | "dept_admin" | "dept_member";
+    slDept?: string;
   }
 
   interface User {


### PR DESCRIPTION
## 概要
本番向けに、TestSiteで検証済みのSL/SharePoint検索機能を追加します。

## 含める変更
- SLユーザーの部署・権限判定
- SharePoint文書のPublish API
- SL同期チェックAPI
- Azure AI SearchのSL ACLフィルタ
- SL文書の引用URL・ダウンロードURL処理
- Common配下/配下外移動時のSharePoint URL追従
- ユーザープロフィール上のSLロール表示

## 含めない変更
- PDF/Excel/Word/PowerPoint変換機能
- Pythonスクリプト
- package.json / package-lock.json の依存追加
- startup.sh
- next.config.js

## 確認済み
- TestSiteでCommon内移動、Common外移動、Common復帰時のURL追従を確認
- `npx tsc --noEmit` 成功
- `npm run lint` 成功
- `npm run build` 成功

## 本番反映前の注意
本PR作成時点では本番未反映です。
マージ前に本番App Serviceの環境変数を整理し、社内通知後に反映します。
