### PR TITLE
Improve SharePoint document comparison retrieval

### DIFF
--- a/src/features/chat-page/chat-services/azure-ai-search/azure-ai-search.ts
+++ b/src/features/chat-page/chat-services/azure-ai-search/azure-ai-search.ts
@@ -270,7 +270,7 @@ export const ExtensionSimilaritySearch = async (props: {
     console.log("[SEARCH:Extension] finalFilter =", finalFilter);
 
     const searchResults = await searchClient.search(searchText, {
-      top: 3,
+      top: 8,
       filter: finalFilter,
       vectorSearchOptions: {
         queries: [

--- a/src/lib/sl-sync.ts
+++ b/src/lib/sl-sync.ts
@@ -853,10 +853,7 @@ async function indexNewSpFiles(params: {
         continue;
       }
 
-      const allChunks: string[] = [];
-      for (const text of textChunks) {
-        allChunks.push(...chunkWithOverlap(text));
-      }
+      const allChunks: string[] = chunkWithOverlap(textChunks.join("\n"));
 
       const scope = resolveScopeFromLocation({
         webUrl: item.webUrl,


### PR DESCRIPTION
## Summary
- Align SharePoint sync chunking with clip-upload chunking by joining extracted text before 2300-character chunking
- Increase Azure AI Search extension retrieval from top 3 to top 8
- Improve comparison quality for SharePoint/SL documents such as quarterly report comparisons

## Validation
- Tested on TestSite
- Ran `npm run build` successfully