### PR TITLE
Add Document Intelligence chunk safeguards

### DIFF
--- a/src/app/(authenticated)/api/sl/sync-check/route.ts
+++ b/src/app/(authenticated)/api/sl/sync-check/route.ts
@@ -106,7 +106,12 @@ export async function POST(req: NextRequest) {
 
     const url = new URL(req.url);
     const apply = url.searchParams.get("apply") === "true";
-    const indexNew = url.searchParams.get("indexNew") === "true";
+    // SL_SYNC_DISABLED=true で新規インデックス化を完全停止できるキルスイッチ
+    const syncDisabled = process.env.SL_SYNC_DISABLED === "true";
+    const indexNew = !syncDisabled && url.searchParams.get("indexNew") === "true";
+    if (syncDisabled) {
+      console.warn("[SL sync-check] SL_SYNC_DISABLED=true: indexNew forced to false");
+    }
     const batchSize = Math.max(
       1,
       Math.min(20, parseInt(url.searchParams.get("batchSize") ?? "5", 10) || 5)

--- a/src/lib/document-extract.ts
+++ b/src/lib/document-extract.ts
@@ -77,14 +77,49 @@ export async function extractWordText(buffer: ArrayBuffer): Promise<string[]> {
   }
 }
 
+const _parsed = parseInt(process.env.DOC_INTELLIGENCE_PAGE_CHUNK ?? "60", 10);
+const DOC_INTELLIGENCE_PAGE_CHUNK =
+  Number.isFinite(_parsed) && _parsed > 0 ? _parsed : 60;
+
+async function getPdfPageCount(buffer: ArrayBuffer): Promise<number> {
+  try {
+    const pdfjsLib = await import("pdfjs-dist/legacy/build/pdf.js");
+    const loadingTask = pdfjsLib.getDocument({ data: new Uint8Array(buffer) });
+    const pdf = await loadingTask.promise;
+    return pdf.numPages;
+  } catch {
+    return 0;
+  }
+}
+
 export async function extractWithDocumentIntelligence(
   buffer: ArrayBuffer
 ): Promise<string[]> {
+  const totalPages = await getPdfPageCount(buffer);
+  if (totalPages === 0) {
+    console.warn("[doc-extract] Could not determine page count, falling back to single call");
+    const client = DocumentIntelligenceInstance();
+    const poller = await client.beginAnalyzeDocument("prebuilt-read", buffer);
+    const { paragraphs } = await poller.pollUntilDone();
+    return (paragraphs ?? []).map((p) => p.content).filter(Boolean);
+  }
+
+  console.log(`[doc-extract] totalPages=${totalPages} chunkSize=${DOC_INTELLIGENCE_PAGE_CHUNK}`);
   const client = DocumentIntelligenceInstance();
-  const poller = await client.beginAnalyzeDocument("prebuilt-read", buffer);
-  const { paragraphs } = await poller.pollUntilDone();
-  if (!paragraphs) return [];
-  return paragraphs.map((p) => p.content).filter(Boolean);
+  const allParagraphs: string[] = [];
+
+  for (let pageStart = 1; pageStart <= totalPages; pageStart += DOC_INTELLIGENCE_PAGE_CHUNK) {
+    const pageEnd = Math.min(pageStart + DOC_INTELLIGENCE_PAGE_CHUNK - 1, totalPages);
+    const pages = `${pageStart}-${pageEnd}`;
+    console.log(`[doc-extract] beginAnalyzeDocument pages=${pages}`);
+
+    const poller = await client.beginAnalyzeDocument("prebuilt-read", buffer, { pages });
+    const result = await poller.pollUntilDone();
+    allParagraphs.push(...(result.paragraphs ?? []).map((p) => p.content).filter(Boolean));
+  }
+
+  console.log(`[doc-extract] total paragraphs extracted: ${allParagraphs.length}`);
+  return allParagraphs;
 }
 
 export async function extractTextFromBuffer(

--- a/src/lib/sl-sync.ts
+++ b/src/lib/sl-sync.ts
@@ -1004,6 +1004,35 @@ async function indexNewSpFiles(params: {
       );
     } catch (e) {
       console.error(`[SL sync] Failed to index ${item.name}:`, e);
+      // sentinel エントリを登録して次回Syncで再キューされないようにする
+      try {
+        const sentinelText = `[INDEXING_FAILED] ${item.name}`;
+        const sentinelEmbRes = await openai.embeddings.create({
+          input: [sentinelText],
+          model: "",
+        });
+        const sentinelEmbedding = sentinelEmbRes.data[0]?.embedding ?? [];
+        const sentinelId = `sl_error_${hashValue(item.id || item.name)}`;
+        await addNewIndexDocs([{
+          id: sentinelId,
+          pageContent: sentinelText,
+          embedding: sentinelEmbedding,
+          metadata: JSON.stringify({ indexingError: true, fileName: item.name }),
+          fileUrl: item.webUrl,
+          effectiveFileUrl: item.webUrl,
+          chatThreadId: "system",
+          user: "system",
+          dept: dept,
+          isSlDoc: true,
+          slScope: "dept_common",
+          slOwner: null,
+          spItemId: item.id,
+          relativePath: item.relativePath ?? null,
+        }]);
+        console.warn(`[SL sync] Sentinel registered for ${item.name} to prevent re-queue`);
+      } catch (sentinelErr) {
+        console.error(`[SL sync] Sentinel registration also failed for ${item.name}:`, sentinelErr);
+      }
       skipped++;
     }
   }


### PR DESCRIPTION
## Summary
- Split Document Intelligence PDF extraction into page chunks
- Add sentinel index entry on SharePoint indexing failure to prevent repeated retries
- Add SL_SYNC_DISABLED kill switch for emergency stop

## Tested
- TestSite deployment succeeded
- 1-page PDF indexing succeeded with pages=1-1
- 100-page PDF indexing succeeded with pages=1-60 and pages=61-100