### PR TITLE
Support msg file extraction for SharePoint sync

### DIFF
--- a/src/lib/document-extract.ts
+++ b/src/lib/document-extract.ts
@@ -122,6 +122,41 @@ export async function extractWithDocumentIntelligence(
   return allParagraphs;
 }
 
+export async function extractMsgText(buffer: ArrayBuffer): Promise<string[]> {
+  try {
+    const MsgReaderModule = require("@kenjiuno/msgreader");
+    const MsgReader = MsgReaderModule.default ?? MsgReaderModule;
+    const reader = new MsgReader(Buffer.from(buffer));
+    const data = reader.getFileData();
+
+    const lines: string[] = [];
+    if (data.subject) lines.push(`件名: ${data.subject}`);
+    if (data.senderName || data.senderEmail) {
+      lines.push(`送信者: ${[data.senderName, data.senderEmail].filter(Boolean).join(" ")}`);
+    }
+    if (Array.isArray(data.recipients) && data.recipients.length > 0) {
+      const toList = data.recipients
+        .map((r: any) => [r.name, r.email].filter(Boolean).join(" "))
+        .join(", ");
+      lines.push(`宛先: ${toList}`);
+    }
+    if (data.messageDeliveryTime) lines.push(`日時: ${data.messageDeliveryTime}`);
+
+    let body: string = data.body ?? "";
+    if (!body && data.bodyHtml) {
+      body = data.bodyHtml.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+    }
+    if (body) lines.push(body);
+
+    const fullText = lines.join("\n").trim();
+    console.log(`[doc-extract] .msg extracted: subject="${data.subject ?? ""}" bodyLen=${body.length}`);
+    return fullText ? [fullText] : [];
+  } catch (e) {
+    console.warn("[doc-extract] .msg parse failed:", e);
+    return [];
+  }
+}
+
 export async function extractTextFromBuffer(
   buffer: ArrayBuffer,
   fileName: string
@@ -129,6 +164,9 @@ export async function extractTextFromBuffer(
   const lower = fileName.toLowerCase();
   if (lower.endsWith(".xlsx") || lower.endsWith(".xlsm")) {
     return extractExcelText(buffer);
+  }
+  if (lower.endsWith(".msg")) {
+    return extractMsgText(buffer);
   }
   return extractWithDocumentIntelligence(buffer);
 }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -15,6 +15,7 @@
         "@azure/search-documents": "^12.0.0",
         "@azure/storage-blob": "^12.17.0",
         "@codemirror/lang-javascript": "^6.2.1",
+        "@kenjiuno/msgreader": "^1.28.0",
         "@markdoc/markdoc": "^0.4.0",
         "@napi-rs/canvas": "^0.1.83",
         "@radix-ui/react-accordion": "^1.1.2",
@@ -766,6 +767,23 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@kenjiuno/decompressrtf": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@kenjiuno/decompressrtf/-/decompressrtf-0.1.4.tgz",
+      "integrity": "sha512-v9c/iFz17jRWyd2cRnrvJg4VOg/4I/VCk+bG8JnoX2gJ9sAesPzo3uTqcmlVXdpasTI8hChpBVw00pghKe3qTQ=="
+    },
+    "node_modules/@kenjiuno/msgreader": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@kenjiuno/msgreader/-/msgreader-1.28.0.tgz",
+      "integrity": "sha512-+iv2rWCGRHmX/3sBwXZzkThEuuywGJjnYsvxj6Kp1L/FDMICQcFrtqN+6MFrnh2d+umtfGtX904wxaYEDZ52MQ==",
+      "dependencies": {
+        "@kenjiuno/decompressrtf": "^0.1.3",
+        "iconv-lite": "^0.6.3"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@lezer/common": {
@@ -6243,6 +6261,17 @@
         "ms": "^2.0.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -10019,6 +10048,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/scheduler": {
       "version": "0.23.2",

--- a/src/package.json
+++ b/src/package.json
@@ -16,6 +16,7 @@
     "@azure/search-documents": "^12.0.0",
     "@azure/storage-blob": "^12.17.0",
     "@codemirror/lang-javascript": "^6.2.1",
+    "@kenjiuno/msgreader": "^1.28.0",
     "@markdoc/markdoc": "^0.4.0",
     "@napi-rs/canvas": "^0.1.83",
     "@radix-ui/react-accordion": "^1.1.2",


### PR DESCRIPTION
## Summary
- Add .msg extraction for SharePoint sync
- Extract subject, sender, recipients, delivery time, and message body before indexing
- Add @kenjiuno/msgreader dependency

## Test
- Confirmed on TestSite that .msg was extracted and indexed:
  - [doc-extract] .msg extracted
  - [SL sync] Indexed ... .msg