### PR TITLE
Improve Teams SharePoint RAG query interpretation

### DIFF
--- a/src/features/teams/teams-app.ts
+++ b/src/features/teams/teams-app.ts
@@ -17,7 +17,6 @@ import {
   recordTeamsThreadUsage,
 } from "./teams-usage-service";
 import { resolveTeamsInstantReply } from "./teams-instant-reply";
-import { requiresTeamsInternalSearch } from "./teams-search-intent";
 import { readLatestTeamsFiles, receiveTeamsFiles } from "./teams-file-service";
 import {
   referencesTeamsUpload,
@@ -172,11 +171,9 @@ async function createTeamsRuntime(): Promise<TeamsRuntime> {
       );
       const officeRequest = parseTeamsOfficeRequest(routingText);
 
-      // Office operations and internal ACL-aware search require the Teams
-      // member's email. General chat and Web search do not.
-      const userEmail = officeRequest || requiresTeamsInternalSearch(text)
-        ? await resolveActivityUserEmail({ activity, api })
-        : null;
+      // The LLM may decide to use ACL-aware internal search after this routing
+      // step, so resolve the Teams member before entering the chat service.
+      const userEmail = await resolveActivityUserEmail({ activity, api });
 
       if (officeRequest) {
         const startMessage = buildOfficeStartMessage(officeRequest);

--- a/src/features/teams/teams-brave-search-service.ts
+++ b/src/features/teams/teams-brave-search-service.ts
@@ -1,7 +1,6 @@
 import "server-only";
 
 import type { TeamsSearchSource } from "./teams-search-service";
-import { requiresTeamsInternalSearch } from "./teams-search-intent";
 import { buildTeamsWebQuery } from "./teams-web-query";
 import {
   extractWeatherPageText,
@@ -43,13 +42,12 @@ export function resolveBraveSearchRequest(message: string): {
   }
 
   const mode = process.env.TEAMS_BRAVE_SEARCH_MODE?.trim().toLowerCase();
-  const skipInternalSearch = !requiresTeamsInternalSearch(trimmed);
   if (mode === "off") {
-    return { enabled: false, query: trimmed, skipInternalSearch };
+    return { enabled: false, query: trimmed, skipInternalSearch: false };
   }
 
   if (mode === "always") {
-    return { enabled: true, query: trimmed, skipInternalSearch };
+    return { enabled: true, query: trimmed, skipInternalSearch: false };
   }
 
   const autoSearchPattern =
@@ -57,7 +55,10 @@ export function resolveBraveSearchRequest(message: string): {
   return {
     enabled: autoSearchPattern.test(trimmed),
     query: trimmed,
-    skipInternalSearch,
+    // Only an explicit /web or /brave command forbids internal tool use.
+    // For every other message, the Teams LLM decides whether internal search
+    // is appropriate instead of relying on a Japanese regular expression.
+    skipInternalSearch: false,
   };
 }
 

--- a/src/features/teams/teams-chat-service.ts
+++ b/src/features/teams/teams-chat-service.ts
@@ -1,9 +1,12 @@
 import "server-only";
 
 import { OpenAIInstance } from "@/features/common/services/openai";
-import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+import type {
+  ChatCompletionMessageParam,
+  ChatCompletionMessageToolCall,
+} from "openai/resources/chat/completions";
 import {
-  searchTeamsKnowledge,
+  searchTeamsKnowledgeWithTarget,
   type TeamsSearchSource,
 } from "./teams-search-service";
 import {
@@ -12,8 +15,15 @@ import {
 } from "./teams-brave-search-service";
 import { resolveTeamsInstantReply } from "./teams-instant-reply";
 import { buildTeamsWebQuery } from "./teams-web-query";
+import {
+  parseTeamsInternalSearchToolArguments,
+  TEAMS_INTERNAL_SEARCH_INSTRUCTIONS,
+  TEAMS_INTERNAL_SEARCH_TOOL,
+  TEAMS_INTERNAL_SEARCH_TOOL_NAME,
+} from "./teams-search-tool";
 
 const MAX_HISTORY_MESSAGES = 20;
+const MAX_INTERNAL_SEARCH_CALLS = 3;
 const conversations = new Map<string, ChatCompletionMessageParam[]>();
 
 export type TeamsChatResult =
@@ -44,43 +54,86 @@ export async function createTeamsChatReply(props: {
 
   const history = conversations.get(props.conversationId) ?? [];
   const braveRequest = resolveBraveSearchRequest(message);
-  const internalSearch = braveRequest.skipInternalSearch
-    ? { context: "", sources: [] as TeamsSearchSource[] }
-    : await searchTeamsKnowledge({
-        query: braveRequest.query,
-        userEmail: props.userEmail,
-      });
   const webSearch = braveRequest.enabled
     ? await searchBraveWeb({
         query: braveRequest.query,
-        startIndex: internalSearch.sources.length + 1,
+        startIndex: 1,
       })
     : { context: "", sources: [] };
-  const allSources = [...internalSearch.sources, ...webSearch.sources];
+  const allSources = [...webSearch.sources];
   const userContent = buildUserContent(
     braveRequest.query,
-    internalSearch.context,
+    "",
     webSearch.context,
-    !braveRequest.skipInternalSearch,
+    false,
     braveRequest.enabled
   );
+  const baseSystemPrompt =
+    process.env.TEAMS_SYSTEM_PROMPT?.trim() ||
+    "あなたはAzureChatのAIアシスタントです。ユーザーと同じ言語で、正確かつ簡潔に回答してください。Teamsで読みやすいMarkdownを使用してください。社内情報については提供された検索資料だけを根拠に回答し、根拠がない場合は分からないと回答してください。検索資料を使用した文には必ず [1] の形式で出典番号を付けてください。";
   const messages: ChatCompletionMessageParam[] = [
     {
       role: "system",
-      content:
-        process.env.TEAMS_SYSTEM_PROMPT?.trim() ||
-        "あなたはAzureChatのAIアシスタントです。ユーザーと同じ言語で、正確かつ簡潔に回答してください。Teamsで読みやすいMarkdownを使用してください。社内情報については提供された検索資料だけを根拠に回答し、根拠がない場合は分からないと回答してください。検索資料を使用した文には必ず [1] の形式で出典番号を付けてください。",
+      content: `${baseSystemPrompt}\n\n${TEAMS_INTERNAL_SEARCH_INSTRUCTIONS}`,
     },
     ...history,
     { role: "user", content: userContent },
   ];
 
-  const completion = await OpenAIInstance().chat.completions.create({
-    model: process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME ?? "",
-    messages,
-  });
+  const openai = OpenAIInstance();
+  let answer = "";
+  let internalSearchCalls = 0;
+  let forceFinalAnswer = false;
 
-  const answer = completion.choices[0]?.message?.content?.trim();
+  while (!answer) {
+    const completion = await openai.chat.completions.create({
+      model: process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME ?? "",
+      messages,
+      ...(!braveRequest.skipInternalSearch && !forceFinalAnswer
+        ? { tools: [TEAMS_INTERNAL_SEARCH_TOOL], tool_choice: "auto" as const }
+        : {}),
+    });
+    const assistantMessage = completion.choices[0]?.message;
+    if (!assistantMessage) {
+      throw new Error("Azure OpenAI returned no assistant message.");
+    }
+
+    const toolCalls = forceFinalAnswer
+      ? []
+      : assistantMessage.tool_calls?.filter(
+          (toolCall) => toolCall.type === "function"
+        ) ?? [];
+    if (toolCalls.length === 0) {
+      answer = assistantMessage.content?.trim() ?? "";
+      break;
+    }
+
+    messages.push({
+      role: "assistant",
+      content: assistantMessage.content,
+      tool_calls: toolCalls,
+    });
+
+    for (const toolCall of toolCalls) {
+      const toolContent = await executeInternalSearchTool({
+        toolCall,
+        userEmail: props.userEmail,
+        allSources,
+        searchCallAllowed: internalSearchCalls < MAX_INTERNAL_SEARCH_CALLS,
+      });
+      if (toolCall.function.name === TEAMS_INTERNAL_SEARCH_TOOL_NAME) {
+        internalSearchCalls++;
+      }
+      messages.push({
+        role: "tool",
+        tool_call_id: toolCall.id,
+        content: toolContent,
+      });
+    }
+
+    forceFinalAnswer = internalSearchCalls >= MAX_INTERNAL_SEARCH_CALLS;
+  }
+
   if (!answer) {
     throw new Error("Azure OpenAI returned an empty response.");
   }
@@ -97,6 +150,76 @@ export async function createTeamsChatReply(props: {
   );
 
   return { type: "reply", text: answerWithSources };
+}
+
+async function executeInternalSearchTool(props: {
+  toolCall: ChatCompletionMessageToolCall;
+  userEmail?: string | null;
+  allSources: TeamsSearchSource[];
+  searchCallAllowed: boolean;
+}): Promise<string> {
+  if (props.toolCall.function.name !== TEAMS_INTERNAL_SEARCH_TOOL_NAME) {
+    return "未対応のツールです。別のツールを呼ばず、回答を作成してください。";
+  }
+  if (!props.searchCallAllowed) {
+    return "社内検索回数の上限に達しました。取得済みの資料だけで回答してください。";
+  }
+
+  try {
+    const args = parseTeamsInternalSearchToolArguments(
+      props.toolCall.function.arguments
+    );
+    const result = await searchTeamsKnowledgeWithTarget({
+      ...args,
+      userEmail: props.userEmail,
+    });
+    if (!result.userEmail) {
+      return "Teamsユーザーのメールアドレスを解決できないため、アクセス権付き社内検索を実行できませんでした。";
+    }
+
+    const context = mergeSearchSources(
+      result.context,
+      result.sources,
+      props.allSources
+    );
+    return `社内検索資料:\n${
+      context || "該当する社内文書は見つかりませんでした。"
+    }`;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn("[teams-search-tool] execution failed", message);
+    return `社内検索を実行できませんでした: ${message.slice(0, 300)}`;
+  }
+}
+
+function mergeSearchSources(
+  context: string,
+  incoming: TeamsSearchSource[],
+  allSources: TeamsSearchSource[]
+): string {
+  const indexMap = new Map<number, number>();
+  for (const source of incoming) {
+    const existing = allSources.find(
+      (item) =>
+        item.kind === source.kind &&
+        item.name === source.name &&
+        (item.url ?? "") === (source.url ?? "")
+    );
+    if (existing) {
+      indexMap.set(source.index, existing.index);
+      continue;
+    }
+
+    const nextIndex =
+      allSources.reduce((max, item) => Math.max(max, item.index), 0) + 1;
+    indexMap.set(source.index, nextIndex);
+    allSources.push({ ...source, index: nextIndex });
+  }
+
+  return context.replace(/\[(\d+)\]/g, (match, rawIndex: string) => {
+    const mapped = indexMap.get(Number(rawIndex));
+    return mapped ? `[${mapped}]` : match;
+  });
 }
 
 function buildUserContent(

--- a/src/features/teams/teams-search-intent.ts
+++ b/src/features/teams/teams-search-intent.ts
@@ -7,7 +7,7 @@ export function requiresTeamsInternalSearch(message: string): boolean {
   const normalized = message.normalize("NFKC").trim();
   if (!normalized) return false;
 
-  return /(?:社内(?:の)?(?:資料|文書|書類|規程|規定|ルール|マニュアル|情報|データ|ナレッジ|検索)|(?:会社|当社)(?:の)?(?:資料|文書|書類|規程|規定|ルール|マニュアル)|社内検索|share\s*point|ai\s*search|(?:SP|SL)(?:上|内|にある|の)(?:資料|文書|書類|ファイル|規程|規定))/i.test(
+  return /(?:社内(?:の)?(?:資料|文書|書類|規程|規定|ルール|マニュアル|情報|データ|ナレッジ|検索)|(?:会社|当社)(?:の)?(?:資料|文書|書類|規程|規定|ルール|マニュアル)|社内検索|share\s*point|ai\s*search|(?:SP|SL)(?:上|内|にある|の)(?:資料|文書|書類|ファイル|規程|規定)|(?:全社共通|全社共有|部署共通|部門共通|部署共有|部門共有)(?:資料|ファイル|フォルダ(?:ー)?)?|(?:個人|自分の|私の)(?:資料|ファイル|フォルダ(?:ー)?)|(?:という|と呼ばれる)\s*フォルダ(?:ー)?)/i.test(
     normalized
   );
 }

--- a/src/features/teams/teams-search-service.ts
+++ b/src/features/teams/teams-search-service.ts
@@ -11,6 +11,7 @@ import {
   buildSlSearchTargetFilter,
   inferSlSearchTarget,
   stripSlSearchTargetTerms,
+  type SlSearchScope,
 } from "@/lib/sl-search-target";
 
 const DEFAULT_SEARCH_TOP = 8;
@@ -35,10 +36,51 @@ export type TeamsOfficeFileCandidate = {
   url: string;
 };
 
+export type TeamsKnowledgeSearchTarget = {
+  query: string;
+  userEmail?: string | null;
+  scope?: SlSearchScope;
+  folder?: string;
+};
+
 export async function searchTeamsKnowledge(props: {
   query: string;
   userEmail?: string | null;
 }): Promise<TeamsSearchResult> {
+  const targetQuery = normalizeTeamsSearchTargetQuery(props.query);
+  const target = inferSlSearchTarget(targetQuery);
+
+  if (target.folderUncertain) {
+    const userEmail = resolveTeamsSearchUserEmail(props.userEmail);
+    const dept = userEmail ? resolveSlAccess(userEmail).dept : "";
+    console.log("[teams-search] folder clarification required", {
+      dept,
+      query: props.query,
+    });
+    return {
+      context:
+        "検索対象のフォルダー名を一意に判断できません。ユーザーにフォルダー名を確認してください。",
+      sources: [],
+      userEmail: userEmail ?? "",
+      dept,
+    };
+  }
+
+  return searchTeamsKnowledgeWithTarget({
+    query: targetQuery,
+    userEmail: props.userEmail,
+    scope: target.scope,
+    folder: target.folder,
+  });
+}
+
+/**
+ * Executes Teams internal search from LLM-produced structured target fields.
+ * ACL resolution remains deterministic and is never delegated to the model.
+ */
+export async function searchTeamsKnowledgeWithTarget(
+  props: TeamsKnowledgeSearchTarget
+): Promise<TeamsSearchResult> {
   assertSearchConfiguration();
 
   const userEmail = resolveTeamsSearchUserEmail(props.userEmail);
@@ -51,28 +93,16 @@ export async function searchTeamsKnowledge(props: {
 
   const access = resolveSlAccess(userEmail);
   const userHash = hashValue(userEmail);
-  const targetQuery = normalizeTeamsSearchTargetQuery(props.query);
-  const target = inferSlSearchTarget(targetQuery);
+  const target = {
+    scope: props.scope,
+    folder: props.folder?.trim() || undefined,
+  };
   const targetFilter = buildSlSearchTargetFilter(target);
   const searchFilter = targetFilter
     ? `(isSlDoc eq true) and (${targetFilter})`
     : "isSlDoc eq true";
-  const effectiveQuery = stripSlSearchTargetTerms(targetQuery, target);
+  const effectiveQuery = stripSlSearchTargetTerms(props.query, target);
   const top = resolveSearchTop();
-
-  if (target.folderUncertain) {
-    console.log("[teams-search] folder clarification required", {
-      dept: access.dept,
-      query: props.query,
-    });
-    return {
-      context:
-        "検索対象のフォルダー名を一意に判断できません。ユーザーにフォルダー名を確認してください。",
-      sources: [],
-      userEmail,
-      dept: access.dept,
-    };
-  }
 
   let filenameMatchedDocs: DocumentSearchResponse[] = [];
   const filenameList = await SimpleSearch(
@@ -121,8 +151,8 @@ export async function searchTeamsKnowledge(props: {
   console.log("[teams-search] completed", {
     dept: access.dept,
     role: access.role,
-    scope: target.scope ?? "all",
-    folder: target.folder ?? "(none)",
+    scope: props.scope ?? "all",
+    folder: props.folder ?? "(none)",
     effectiveQuery,
     filenameMatches: filenameMatchedDocs.length,
     results: response.response.length,

--- a/src/features/teams/teams-search-service.ts
+++ b/src/features/teams/teams-search-service.ts
@@ -7,6 +7,11 @@ import {
 } from "@/features/chat-page/chat-services/azure-ai-search/azure-ai-search";
 import { hashValue } from "@/features/auth-page/helpers";
 import { resolveSlAccess } from "@/lib/sl-dept";
+import {
+  buildSlSearchTargetFilter,
+  inferSlSearchTarget,
+  stripSlSearchTargetTerms,
+} from "@/lib/sl-search-target";
 
 const DEFAULT_SEARCH_TOP = 8;
 const MAX_CONTEXT_CHARACTERS = 24_000;
@@ -45,17 +50,66 @@ export async function searchTeamsKnowledge(props: {
   }
 
   const access = resolveSlAccess(userEmail);
-  const response = await ExtensionSimilaritySearch({
-    searchText: props.query,
-    vectors: ["embedding"],
-    apiKey: requiredEnv("AZURE_SEARCH_API_KEY"),
-    searchName: requiredEnv("AZURE_SEARCH_NAME"),
-    indexName: requiredEnv("AZURE_SEARCH_INDEX_NAME"),
-    filter: "isSlDoc eq true",
-    deptLower: access.dept,
-    userHash: hashValue(userEmail),
-    top: resolveSearchTop(),
-  });
+  const userHash = hashValue(userEmail);
+  const target = inferSlSearchTarget(props.query);
+  const targetFilter = buildSlSearchTargetFilter(target);
+  const searchFilter = targetFilter
+    ? `(isSlDoc eq true) and (${targetFilter})`
+    : "isSlDoc eq true";
+  const effectiveQuery = stripSlSearchTargetTerms(props.query, target);
+  const top = resolveSearchTop();
+
+  if (target.folderUncertain) {
+    console.log("[teams-search] folder clarification required", {
+      dept: access.dept,
+      query: props.query,
+    });
+    return {
+      context:
+        "検索対象のフォルダー名を一意に判断できません。ユーザーにフォルダー名を確認してください。",
+      sources: [],
+      userEmail,
+      dept: access.dept,
+    };
+  }
+
+  let filenameMatchedDocs: DocumentSearchResponse[] = [];
+  const filenameList = await SimpleSearch(
+    "*",
+    searchFilter,
+    access.dept,
+    1000,
+    userHash
+  );
+  if (filenameList.status === "OK") {
+    filenameMatchedDocs = findFilenameMatches(
+      filenameList.response,
+      effectiveQuery
+    );
+  } else {
+    console.warn(
+      "[teams-search] filename-first search failed; using vector fallback",
+      filenameList.errors
+    );
+  }
+
+  const response =
+    filenameMatchedDocs.length > 0
+      ? {
+          status: "OK" as const,
+          response: filenameMatchedDocs.slice(0, Math.max(top, 20)),
+        }
+      : await ExtensionSimilaritySearch({
+          searchText: effectiveQuery,
+          vectors: ["embedding"],
+          apiKey: requiredEnv("AZURE_SEARCH_API_KEY"),
+          searchName: requiredEnv("AZURE_SEARCH_NAME"),
+          indexName: requiredEnv("AZURE_SEARCH_INDEX_NAME"),
+          filter: searchFilter,
+          deptLower: access.dept,
+          userHash,
+          top,
+        });
 
   if (response.status !== "OK") {
     const detail = response.errors?.map((error) => error.message).join("; ");
@@ -66,6 +120,10 @@ export async function searchTeamsKnowledge(props: {
   console.log("[teams-search] completed", {
     dept: access.dept,
     role: access.role,
+    scope: target.scope ?? "all",
+    folder: target.folder ?? "(none)",
+    effectiveQuery,
+    filenameMatches: filenameMatchedDocs.length,
     results: response.response.length,
     sources: formatted.sources.length,
   });
@@ -372,6 +430,37 @@ function normalizeFileSearchText(value: string): string {
     .toLowerCase()
     .replace(/\.(pdf|docx|xlsx)$/i, "")
     .replace(/[\s\u3000「」『』【】()（）・_\-]/g, "");
+}
+
+function findFilenameMatches(
+  results: DocumentSearchResponse[],
+  query: string
+): DocumentSearchResponse[] {
+  const normalizedQuery = normalizeFileSearchText(query);
+  if (!normalizedQuery) return [];
+
+  return results.filter(({ document }) => {
+    const candidates = [
+      document.metadata ?? "",
+      getFileNameFromUrl(document.effectiveFileUrl ?? document.fileUrl),
+    ];
+
+    return candidates.some((candidate) => {
+      const normalizedName = normalizeFileSearchText(candidate);
+      return (
+        normalizedName.length >= 4 && normalizedQuery.includes(normalizedName)
+      );
+    });
+  });
+}
+
+function getFileNameFromUrl(value?: string | null): string {
+  const rawName = (value ?? "").split("/").pop() ?? "";
+  try {
+    return decodeURIComponent(rawName);
+  } catch {
+    return rawName;
+  }
 }
 
 function requiredEnv(name: string): string {

--- a/src/features/teams/teams-search-service.ts
+++ b/src/features/teams/teams-search-service.ts
@@ -51,12 +51,13 @@ export async function searchTeamsKnowledge(props: {
 
   const access = resolveSlAccess(userEmail);
   const userHash = hashValue(userEmail);
-  const target = inferSlSearchTarget(props.query);
+  const targetQuery = normalizeTeamsSearchTargetQuery(props.query);
+  const target = inferSlSearchTarget(targetQuery);
   const targetFilter = buildSlSearchTargetFilter(target);
   const searchFilter = targetFilter
     ? `(isSlDoc eq true) and (${targetFilter})`
     : "isSlDoc eq true";
-  const effectiveQuery = stripSlSearchTargetTerms(props.query, target);
+  const effectiveQuery = stripSlSearchTargetTerms(targetQuery, target);
   const top = resolveSearchTop();
 
   if (target.folderUncertain) {
@@ -430,6 +431,13 @@ function normalizeFileSearchText(value: string): string {
     .toLowerCase()
     .replace(/\.(pdf|docx|xlsx)$/i, "")
     .replace(/[\s\u3000「」『』【】()（）・_\-]/g, "");
+}
+
+function normalizeTeamsSearchTargetQuery(value: string): string {
+  return value.replace(
+    /[、,]\s*(?=(?:という|と呼ばれる)\s*フォルダ(?:ー)?)/g,
+    ""
+  );
 }
 
 function findFilenameMatches(

--- a/src/features/teams/teams-search-tool.ts
+++ b/src/features/teams/teams-search-tool.ts
@@ -1,0 +1,95 @@
+import type { ChatCompletionTool } from "openai/resources/chat/completions";
+
+import type { SlSearchScope } from "@/lib/sl-search-target";
+
+export type TeamsInternalSearchToolArguments = {
+  query: string;
+  scope?: SlSearchScope;
+  folder?: string;
+};
+
+const VALID_SCOPES = new Set<SlSearchScope>([
+  "all",
+  "personal",
+  "dept_common",
+  "global_common",
+]);
+
+export const TEAMS_INTERNAL_SEARCH_TOOL_NAME = "teams_internal_search";
+
+export const TEAMS_INTERNAL_SEARCH_INSTRUCTIONS =
+  "社内・SharePoint・部署共通・全社共通・個人資料について、文書を読んで回答する必要がある場合はteams_internal_searchを使用してください。" +
+  "フォルダー指定は助詞や表記にかかわらず意味から解釈してください。たとえば「可能性調査というフォルダー」「『可能性調査』のフォルダーで」「可能性調査フォルダー内」は、いずれもfolder=可能性調査です。" +
+  "部署共通はscope=dept_common、全社共通はscope=global_common、個人・自分・私の資料はscope=personalです。" +
+  "queryには検索場所を示す語を除き、探す内容・比較項目・文書名を具体的に設定してください。" +
+  "一般知識、雑談、天気、Web情報だけで答える質問ではこのツールを使用しないでください。";
+
+export const TEAMS_INTERNAL_SEARCH_TOOL: ChatCompletionTool = {
+  type: "function",
+  function: {
+    name: TEAMS_INTERNAL_SEARCH_TOOL_NAME,
+    description:
+      "アクセス権を適用して社内SharePoint文書を検索します。検索範囲やフォルダー名はユーザーの自然な表現から意味的に抽出してください。",
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description:
+            "検索内容。検索場所の表現を除き、文書名・対象・比較項目などを含めます。",
+        },
+        scope: {
+          type: "string",
+          enum: ["all", "personal", "dept_common", "global_common"],
+          description:
+            "検索範囲。部署共通はdept_common、全社共通はglobal_common、個人資料はpersonal、明示がなければall。",
+        },
+        folder: {
+          type: "string",
+          description:
+            "明示されたSharePointフォルダー名。引用符、「という」、助詞「の」「で」「から」「内」などは含めません。",
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+  },
+};
+
+export function parseTeamsInternalSearchToolArguments(
+  value: string
+): TeamsInternalSearchToolArguments {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("Teams internal search tool returned invalid JSON.");
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Teams internal search tool arguments must be an object.");
+  }
+
+  const input = parsed as Record<string, unknown>;
+  const query = normalizeText(input.query);
+  if (!query) {
+    throw new Error("Teams internal search tool query is required.");
+  }
+
+  const rawScope = normalizeText(input.scope);
+  if (rawScope && !VALID_SCOPES.has(rawScope as SlSearchScope)) {
+    throw new Error(`Unsupported Teams internal search scope: ${rawScope}`);
+  }
+
+  const folder = normalizeText(input.folder);
+  return {
+    query,
+    ...(rawScope ? { scope: rawScope as SlSearchScope } : {}),
+    ...(folder ? { folder } : {}),
+  };
+}
+
+function normalizeText(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value.normalize("NFKC").trim().slice(0, 500);
+}

--- a/src/scripts/test-teams-search-intent.cjs
+++ b/src/scripts/test-teams-search-intent.cjs
@@ -29,6 +29,14 @@ assert.equal(requiresTeamsInternalSearch("社内規程によれば申請期限�
 assert.equal(requiresTeamsInternalSearch("SharePointの資料を調べて"), true);
 assert.equal(requiresTeamsInternalSearch("SPにある規程を確認して"), true);
 assert.equal(requiresTeamsInternalSearch("AI Searchで検索して"), true);
+assert.equal(
+  requiresTeamsInternalSearch(
+    "部署共通フォルダーにある、可能性調査、というフォルダーから、処分場の候補地を調べて"
+  ),
+  true
+);
+assert.equal(requiresTeamsInternalSearch("個人フォルダーの財務資料を調べて"), true);
+assert.equal(requiresTeamsInternalSearch("全社共通から就業規則を調べて"), true);
 
 assert.equal(requiresTeamsInternalSearch("浜松の明日の天気は？"), false);
 assert.equal(requiresTeamsInternalSearch("一般的な有給休暇の制度を教えて"), false);

--- a/src/scripts/test-teams-search-tool.cjs
+++ b/src/scripts/test-teams-search-tool.cjs
@@ -1,0 +1,266 @@
+const assert = require("assert");
+const fs = require("fs");
+const Module = require("module");
+const path = require("path");
+const ts = require("typescript");
+
+function loadTypeScriptModule(relativePath, mocks = {}) {
+  const fileName = path.resolve(relativePath);
+  const source = fs.readFileSync(fileName, "utf8");
+  const javascript = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+  }).outputText;
+  const loaded = new Module(fileName);
+  loaded.filename = fileName;
+  loaded.paths = Module._nodeModulePaths(path.dirname(fileName));
+  const originalLoad = Module._load;
+  Module._load = function (request, parent, isMain) {
+    if (Object.prototype.hasOwnProperty.call(mocks, request)) {
+      return mocks[request];
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  try {
+    loaded._compile(javascript, fileName);
+  } finally {
+    Module._load = originalLoad;
+  }
+  return loaded.exports;
+}
+
+const searchTool = loadTypeScriptModule("features/teams/teams-search-tool.ts");
+
+assert.deepEqual(
+  searchTool.parseTeamsInternalSearchToolArguments(
+    JSON.stringify({
+      query: "各候補地 メリット デメリット",
+      scope: "dept_common",
+      folder: "可能性調査",
+    })
+  ),
+  {
+    query: "各候補地 メリット デメリット",
+    scope: "dept_common",
+    folder: "可能性調査",
+  }
+);
+assert.throws(
+  () =>
+    searchTool.parseTeamsInternalSearchToolArguments(
+      JSON.stringify({ query: "候補地", scope: "unknown" })
+    ),
+  /Unsupported Teams internal search scope/
+);
+assert.match(
+  searchTool.TEAMS_INTERNAL_SEARCH_INSTRUCTIONS,
+  /「『可能性調査』のフォルダーで」/
+);
+assert.equal(
+  searchTool.TEAMS_INTERNAL_SEARCH_TOOL.function.parameters.additionalProperties,
+  false
+);
+
+const completionQueue = [];
+const searchCalls = [];
+const completionCalls = [];
+const openai = {
+  chat: {
+    completions: {
+      create: async (request) => {
+        completionCalls.push(request);
+        const next = completionQueue.shift();
+        if (!next) throw new Error("Unexpected completion call");
+        return next;
+      },
+    },
+  },
+};
+
+const chatService = loadTypeScriptModule("features/teams/teams-chat-service.ts", {
+  "server-only": {},
+  "@/features/common/services/openai": {
+    OpenAIInstance: () => openai,
+  },
+  "./teams-search-service": {
+    searchTeamsKnowledgeWithTarget: async (args) => {
+      searchCalls.push(args);
+      return {
+        context: "[1] 候補地資料\nA候補地のメリットとデメリット",
+        sources: [
+          {
+            index: 1,
+            name: "候補地資料.docx",
+            url: "https://example.test/candidate.docx",
+            kind: "internal",
+          },
+        ],
+        userEmail: args.userEmail || "",
+        dept: "bm",
+      };
+    },
+  },
+  "./teams-brave-search-service": {
+    resolveBraveSearchRequest: (message) => ({
+      enabled: false,
+      query: message,
+      skipInternalSearch: false,
+    }),
+    searchBraveWeb: async () => ({ context: "", sources: [] }),
+  },
+  "./teams-instant-reply": {
+    resolveTeamsInstantReply: () => null,
+  },
+  "./teams-web-query": {
+    buildTeamsWebQuery: (query) => ({ query, enriched: false }),
+  },
+  "./teams-search-tool": searchTool,
+});
+
+const slSearchTarget = loadTypeScriptModule("lib/sl-search-target.ts");
+const vectorSearchCalls = [];
+const searchService = loadTypeScriptModule(
+  "features/teams/teams-search-service.ts",
+  {
+    "server-only": {},
+    "@/features/chat-page/chat-services/azure-ai-search/azure-ai-search": {
+      SimpleSearch: async () => ({ status: "OK", response: [] }),
+      ExtensionSimilaritySearch: async (args) => {
+        vectorSearchCalls.push(args);
+        return {
+          status: "OK",
+          response: [
+            {
+              document: {
+                metadata: "候補地資料.docx",
+                pageContent: "A候補地のメリットとデメリット",
+                fileUrl: "https://example.test/candidate.docx",
+              },
+            },
+          ],
+        };
+      },
+    },
+    "@/features/auth-page/helpers": {
+      hashValue: (value) => `hash:${value}`,
+    },
+    "@/lib/sl-dept": {
+      resolveSlAccess: () => ({ dept: "bm", role: "dept_admin" }),
+    },
+    "@/lib/sl-search-target": slSearchTarget,
+  }
+);
+
+process.env.AZURE_OPENAI_API_KEY = "test-key";
+process.env.AZURE_OPENAI_API_INSTANCE_NAME = "test-instance";
+process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME = "test-deployment";
+process.env.AZURE_OPENAI_API_EMBEDDINGS_DEPLOYMENT_NAME = "test-embeddings";
+process.env.AZURE_OPENAI_API_VERSION = "test-version";
+process.env.AZURE_SEARCH_API_KEY = "test-search-key";
+process.env.AZURE_SEARCH_NAME = "test-search-name";
+process.env.AZURE_SEARCH_INDEX_NAME = "test-search-index";
+
+async function run() {
+  completionQueue.push(
+    {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call-folder-search",
+                type: "function",
+                function: {
+                  name: searchTool.TEAMS_INTERNAL_SEARCH_TOOL_NAME,
+                  arguments: JSON.stringify({
+                    query: "各候補地 メリット デメリット",
+                    scope: "dept_common",
+                    folder: "可能性調査",
+                  }),
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "比較結果です。[1]",
+          },
+        },
+      ],
+    }
+  );
+
+  const scopedReply = await chatService.createTeamsChatReply({
+    conversationId: "folder-variation-test",
+    message:
+      "部署共通フォルダーの「可能性調査」のフォルダーで、各候補地のメリットデメリットを比較表にして",
+    userEmail: "USER@example.com",
+  });
+  assert.equal(scopedReply.type, "reply");
+  assert.match(scopedReply.text, /比較結果です。\[1\]/);
+  assert.match(scopedReply.text, /候補地資料\.docx/);
+  assert.deepEqual(searchCalls[0], {
+    query: "各候補地 メリット デメリット",
+    scope: "dept_common",
+    folder: "可能性調査",
+    userEmail: "USER@example.com",
+  });
+  assert.equal(completionCalls[0].tool_choice, "auto");
+  assert.equal(completionCalls[0].tools[0].function.name, "teams_internal_search");
+  assert.equal(
+    completionCalls[1].messages.at(-1).tool_call_id,
+    "call-folder-search"
+  );
+
+  completionQueue.push({
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: "東京は日本の首都です。",
+        },
+      },
+    ],
+  });
+  const generalReply = await chatService.createTeamsChatReply({
+    conversationId: "general-question-test",
+    message: "日本の首都は？",
+    userEmail: "USER@example.com",
+  });
+  assert.equal(generalReply.text, "東京は日本の首都です。");
+  assert.equal(searchCalls.length, 1);
+
+  await searchService.searchTeamsKnowledgeWithTarget({
+    query: "各候補地 メリット デメリット",
+    scope: "dept_common",
+    folder: "可能性調査",
+    userEmail: "user@example.com",
+  });
+  assert.equal(vectorSearchCalls.length, 1);
+  assert.equal(vectorSearchCalls[0].searchText, "各候補地 メリット デメリット");
+  assert.match(vectorSearchCalls[0].filter, /slScope eq 'dept_common'/);
+  assert.match(
+    vectorSearchCalls[0].filter,
+    /search\.ismatch\('可能性調査', 'relativePath'/
+  );
+  assert.equal(vectorSearchCalls[0].deptLower, "bm");
+  assert.equal(vectorSearchCalls[0].userHash, "hash:user@example.com");
+
+  console.log("Teams LLM search tool tests passed.");
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- Add scoped SharePoint search support to Teams
- Use LLM tool calling to interpret natural folder expressions and generate `query`, `scope`, and `folder`
- Reuse the existing Teams ACL-aware Azure AI Search and citation handling
- Keep the AzureChat Web implementation unchanged

## Verification

- Verified both folder expressions in the TestSite Teams Bot
  - `可能性調査、というフォルダー`
  - `「可能性調査」のフォルダーで`
- `node scripts/test-teams-search-tool.cjs`
- `node scripts/test-sl-search-target.cjs`
- `node scripts/test-teams-search-intent.cjs`
- `npm run build`